### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: c
+sudo: false
+os:
+    - osx
+    - linux
+    
+compiler:
+    - clang
+    - gcc
+
+matrix:
+    exclude:
+        - os: osx
+          compiler: gcc
+    fast_finish:
+        - true
+
+script: make
+
+after_success:
+    - ./tests_unit 
+    - ./tests_openssl 200

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/digitalbitbox/mcu.svg?branch=master)](https://travis-ci.org/digitalbitbox/mcu)
+
 MCU code for the Digital Bitbox hardware wallet.
 
 All communication to the hardware wallet enters and exits a single gateway `char *commander(const char *command)` that receives an encrypted command and returns an encrypted reply. The communication protocol is desribed in the [API](https://digitalbitbox.com/api.html). The code will compile on a computer by typing `make` - see the `tests_cmdline.c` code for a simple example and the `tests_api.c` code to test the API.

--- a/random.c
+++ b/random.c
@@ -44,7 +44,9 @@ void random_init(void)
 int random_bytes(uint8_t *buf, uint32_t len, uint8_t update_seed)
 {
 	(void) update_seed;
-    fread(buf, 1, len, f);
+    if (fread(buf, 1, len, f) != len) {
+      return 1; // error
+    }
     return 0;
 }
 

--- a/tests_openssl.c
+++ b/tests_openssl.c
@@ -35,8 +35,8 @@
 
 int main(int argc, char *argv[])
 {
-	uint8_t sig[64], pub_key33[33], pub_key65[65], priv_key[32], msg[256], buffer[1000], hash[32], msg_len, *p;
-	uint32_t i, j, p_len;
+	uint8_t sig[64], pub_key33[33], pub_key65[65], priv_key[32], msg[256], buffer[1000], hash[32], msg_len = 0, *p;
+	uint32_t i, j, p_len = 0;
 	SHA256_CTX sha256;
 	EC_GROUP *ecgroup;
     EC_KEY *eckey;

--- a/utils.c
+++ b/utils.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 #include "utils.h"
 #include "commander.h"
@@ -100,18 +101,18 @@ void utils_uint64_to_varint(char *vi, int *l, uint64_t i)
     char v[VARINT_LEN];  
     
     if (i<0xfd) {
-        sprintf(v, "%02llx", i);
+        sprintf(v, "%02" PRIu64 , i);
         len = 2;
     } else if (i <= 0xffff) {
-        sprintf(v, "%04llx", i);
+        sprintf(v, "%04" PRIu64 , i);
         sprintf(vi, "fd");
         len = 4;
     } else if (i <= 0xffffffff) {
-        sprintf(v, "%08llx", i);
+        sprintf(v, "%08" PRIu64 , i);
         sprintf(vi, "fe");
         len = 8;
     } else {
-        sprintf(v, "%016llx", i);
+        sprintf(v, "%016" PRIu64 , i);
         sprintf(vi, "ff");
         len = 16;
     }
@@ -153,7 +154,7 @@ int utils_varint_to_uint64(const char *vi, uint64_t *i)
     } else {
         strncpy(v, vi, len);
     }
-    sscanf(v, "%llx", i);
+    sscanf(v, "%" PRIu64 , i);
    
     return len;
 }

--- a/wallet.c
+++ b/wallet.c
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <inttypes.h>
 
 #include "commander.h"
 #include "ripemd160.h"
@@ -466,14 +467,14 @@ char *wallet_deserialize_output(const char *hex, uint64_t hex_len, const char *k
         memset(outval, 0, sizeof(outval));
         strncpy(outval, hex + idx, 16);
         utils_reverse_hex(outval, 16);
-        sscanf(outval, "%llx", &outValue);
+        sscanf(outval, "%" PRIu64, &outValue);
         idx += 16;                               
         if (hex_len < idx + 16) {return NULL;}
         idx += utils_varint_to_uint64(hex + idx, &n_len);
        
         memset(outval, 0, sizeof(outval));
         memset(outaddr, 0, sizeof(outaddr));
-        sprintf(outval, "{\"value\": %llu, ", outValue);
+        sprintf(outval, "{\"value\": %" PRIu64 ", ", outValue);
         sprintf(outaddr, "\"script\": \"%.*s\"}", (int)n_len * 2, hex + idx);
         idx += n_len * 2; // chars = 2 * bytes 
        


### PR DESCRIPTION
Builds on top of https://github.com/digitalbitbox/mcu/pull/1.

You'd need to go to https://travis-ci.org/ and activate it there. It's free.
Travis is used by Bitcoin Core, libsecp256k1, libbitcoin and many other projects.

Currently only Linux is on by default. We'd have to ask the support to activate OS X (I don't know the requirements, but we had also OS X in Open Transactions).

It runs tests_unit  and tests_openssl 200, but tests_openssl currently always returns 0 / success.

The change in random.c is needed because Travis still runs on Ubuntu 12.04 with GCC 4.6. If you want a higher version of GCC you could install it via the .travis.yml file, but that makes the build a lot slower.