### PR TITLE
Travis astyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 
 before_script:
     - cd $TRAVIS_BUILD_DIR
-    - if astyle --style=stroustrup --indent-switches --indent-labels --pad-oper --pad-header --align-pointer=name --add-brackets --convert-tabs --max-code-length=90 --break-after-logical --suffix=none *.c *.h --recursive --dry-run -Q | grep "Formatted" ; then exit 1 ; fi
+    - if astyle --style=stroustrup --indent-switches --indent-labels --pad-oper --pad-header --align-pointer=name --add-brackets --convert-tabs --max-code-length=90 --break-after-logical --suffix=none *.c *.h --recursive --exclude=astyle --dry-run -Q | grep "Formatted" ; then exit 1 ; fi
 
 script: 
     - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,16 @@ matrix:
     fast_finish:
         - true
 
+before_install: 
+    - wget http://sourceforge.net/projects/astyle/files/astyle/astyle%202.05.1/astyle_2.05.1_linux.tar.gz
+    - tar xfv astyle_2.05.1_linux.tar.gz
+    - cd astyle/build/gcc && make
+    - export PATH=$PATH:$PWD/bin/
+
+before_script:
+    - cd $TRAVIS_BUILD_DIR
+    - if astyle --style=stroustrup --indent-switches --indent-labels --pad-oper --pad-header --align-pointer=name --add-brackets --convert-tabs --max-code-length=90 --break-after-logical --suffix=none *.c *.h --recursive --dry-run -Q | grep "Formatted" ; then exit 1 ; fi
+
 script: 
     - make
     - ./tests/tests_unit 

--- a/README.md
+++ b/README.md
@@ -13,3 +13,10 @@ Cryptographic: secp256k1, AES-256-CBC, SHA2, HMAC, PBKDF2, RIPEMD160.
 Encoding: Base-64, Base-58-check. 
 Bitcoin: BIP32, BIP39, BIP44.
 Other: JSMN (minimal JSON).
+
+### Contributing
+
+Please do *NOT* use an editor that automatically reformats.
+
+Use the coding style set by astyle (http://astyle.sourceforge.net/) with the following parameteres:
+> astyle --style=stroustrup --indent-switches --indent-labels --pad-oper --pad-header --align-pointer=name --add-brackets --convert-tabs --max-code-length=90 --break-after-logical --suffix=none *.c *.h --recursive


### PR DESCRIPTION
The build will fail if the coding style is not
> astyle --style=stroustrup --indent-switches --indent-labels --pad-oper --pad-header --align-pointer=name --add-brackets --convert-tabs --max-code-length=90 --break-after-logical --suffix=none *.c *.h --dry-run -Q

Travis will list the file with the problem (example: https://travis-ci.org/lclc/mcu/jobs/67420821)
