### PR TITLE
-Wwrite-strings, -Wcast-qual, -Wmissing-prototypes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ set(LIBRARY_OUTPUT_PATH  ${CMAKE_CURRENT_BINARY_DIR}/lib)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W -Wall -Wextra -Werror -Wredundant-decls -Wstrict-prototypes -Wundef -Wshadow -Wpointer-arith -Wmultichar -Wformat-nonliteral -Winit-self -Wformat-security -Wold-style-definition -Wmissing-include-dirs -Wbad-function-cast -Winline -Wnested-externs -Wfloat-equal -Wmissing-declarations -Wswitch-default -Wwrite-strings")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W -Wall -Wextra -Werror -Wredundant-decls -Wstrict-prototypes -Wundef -Wshadow -Wpointer-arith -Wmultichar -Wformat-nonliteral -Winit-self -Wformat-security -Wold-style-definition -Wmissing-include-dirs -Wbad-function-cast -Winline -Wnested-externs -Wfloat-equal -Wmissing-declarations -Wswitch-default -Wwrite-strings -Wcast-qual")
 
 if(APPLE)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ set(LIBRARY_OUTPUT_PATH  ${CMAKE_CURRENT_BINARY_DIR}/lib)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W -Wall -Wextra -Werror -Wredundant-decls -Wstrict-prototypes -Wundef -Wshadow -Wpointer-arith -Wmultichar -Wformat-nonliteral -Winit-self -Wformat-security -Wold-style-definition -Wmissing-include-dirs -Wbad-function-cast -Winline -Wnested-externs -Wfloat-equal -Wmissing-declarations -Wswitch-default -Wwrite-strings -Wcast-qual")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W -Wall -Wextra -Werror -Wredundant-decls -Wstrict-prototypes -Wundef -Wshadow -Wpointer-arith -Wmultichar -Wformat-nonliteral -Winit-self -Wformat-security -Wold-style-definition -Wmissing-include-dirs -Wbad-function-cast -Winline -Wnested-externs -Wfloat-equal -Wmissing-declarations -Wswitch-default -Wwrite-strings -Wcast-qual -Wmissing-prototypes")
 
 if(APPLE)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ set(LIBRARY_OUTPUT_PATH  ${CMAKE_CURRENT_BINARY_DIR}/lib)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W -Wall -Wextra -Werror -Wredundant-decls -Wstrict-prototypes -Wundef -Wshadow -Wpointer-arith -Wmultichar -Wformat-nonliteral -Winit-self -Wformat-security -Wold-style-definition -Wmissing-include-dirs -Wbad-function-cast -Winline -Wnested-externs -Wfloat-equal -Wmissing-declarations -Wswitch-default -Wwrite-strings -Wcast-qual -Wmissing-prototypes")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W -Wall -Wextra -Werror -pedantic -Wredundant-decls -Wstrict-prototypes -Wundef -Wshadow -Wpointer-arith -Wmultichar -Wformat-nonliteral -Winit-self -Wformat-security -Wold-style-definition -Wmissing-include-dirs -Wbad-function-cast -Winline -Wnested-externs -Wfloat-equal -Wmissing-declarations -Wswitch-default -Wwrite-strings -Wcast-qual -Wmissing-prototypes")
 
 if(APPLE)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ set(LIBRARY_OUTPUT_PATH  ${CMAKE_CURRENT_BINARY_DIR}/lib)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W -Wall -Wextra -Werror -Wredundant-decls -Wstrict-prototypes -Wundef -Wshadow -Wpointer-arith -Wmultichar -Wformat-nonliteral -Winit-self -Wformat-security -Wold-style-definition -Wmissing-include-dirs -Wbad-function-cast -Winline -Wnested-externs -Wfloat-equal -Wmissing-declarations -Wswitch-default")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W -Wall -Wextra -Werror -Wredundant-decls -Wstrict-prototypes -Wundef -Wshadow -Wpointer-arith -Wmultichar -Wformat-nonliteral -Winit-self -Wformat-security -Wold-style-definition -Wmissing-include-dirs -Wbad-function-cast -Winline -Wnested-externs -Wfloat-equal -Wmissing-declarations -Wswitch-default -Wwrite-strings")
 
 if(APPLE)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations")

--- a/src/aes.c
+++ b/src/aes.c
@@ -357,10 +357,10 @@ static void copy_block_nn( void *d, const void *s, uint_8t nn )
 static void xor_block( void *d, const void *s )
 {
 #if defined( HAVE_UINT_32T )
-    ((uint_32t *)d)[ 0] ^= ((uint_32t *)s)[ 0];
-    ((uint_32t *)d)[ 1] ^= ((uint_32t *)s)[ 1];
-    ((uint_32t *)d)[ 2] ^= ((uint_32t *)s)[ 2];
-    ((uint_32t *)d)[ 3] ^= ((uint_32t *)s)[ 3];
+    ((uint_32t *)d)[ 0] ^= ((const uint_32t *)s)[ 0];
+    ((uint_32t *)d)[ 1] ^= ((const uint_32t *)s)[ 1];
+    ((uint_32t *)d)[ 2] ^= ((const uint_32t *)s)[ 2];
+    ((uint_32t *)d)[ 3] ^= ((const uint_32t *)s)[ 3];
 #else
     ((uint_8t *)d)[ 0] ^= ((uint_8t *)s)[ 0];
     ((uint_8t *)d)[ 1] ^= ((uint_8t *)s)[ 1];
@@ -384,10 +384,10 @@ static void xor_block( void *d, const void *s )
 static void copy_and_key( void *d, const void *s, const void *k )
 {
 #if defined( HAVE_UINT_32T )
-    ((uint_32t *)d)[ 0] = ((uint_32t *)s)[ 0] ^ ((uint_32t *)k)[ 0];
-    ((uint_32t *)d)[ 1] = ((uint_32t *)s)[ 1] ^ ((uint_32t *)k)[ 1];
-    ((uint_32t *)d)[ 2] = ((uint_32t *)s)[ 2] ^ ((uint_32t *)k)[ 2];
-    ((uint_32t *)d)[ 3] = ((uint_32t *)s)[ 3] ^ ((uint_32t *)k)[ 3];
+    ((uint_32t *)d)[ 0] = ((const uint_32t *)s)[ 0] ^ ((const uint_32t *)k)[ 0];
+    ((uint_32t *)d)[ 1] = ((const uint_32t *)s)[ 1] ^ ((const uint_32t *)k)[ 1];
+    ((uint_32t *)d)[ 2] = ((const uint_32t *)s)[ 2] ^ ((const uint_32t *)k)[ 2];
+    ((uint_32t *)d)[ 3] = ((const uint_32t *)s)[ 3] ^ ((const uint_32t *)k)[ 3];
 #elif 1
     ((uint_8t *)d)[ 0] = ((uint_8t *)s)[ 0] ^ ((uint_8t *)k)[ 0];
     ((uint_8t *)d)[ 1] = ((uint_8t *)s)[ 1] ^ ((uint_8t *)k)[ 1];

--- a/src/base58.c
+++ b/src/base58.c
@@ -41,7 +41,7 @@ static const int8_t b58digits_map[] = {
 static int b58tobin(void *bin, size_t *binszp, const char *b58)
 {
     size_t binsz = *binszp;
-    const unsigned char *b58u = (void *)b58;
+    const unsigned char *b58u = (const void *)b58;
     unsigned char *binu = bin;
     size_t outisz = (binsz + 3) / 4;
     uint32_t outi[outisz];

--- a/src/bip32.c
+++ b/src/bip32.c
@@ -60,7 +60,7 @@ int hdnode_from_seed(const uint8_t *seed, int seed_len, HDNode *out)
     out->depth = 0;
     out->fingerprint = 0x00000000;
     out->child_num = 0;
-    hmac_sha512((uint8_t *)"Bitcoin seed", 12, seed, seed_len, I);
+    hmac_sha512((const uint8_t *)"Bitcoin seed", 12, seed, seed_len, I);
     memcpy(out->private_key, I, 32);
 
     if (!uECC_isValid(out->private_key)) {

--- a/src/commander.c
+++ b/src/commander.c
@@ -812,7 +812,7 @@ int commander_test_static_functions(void)
     }
 
     // test json_report overflows
-    char val[] = { [0 ... COMMANDER_REPORT_SIZE] = '1' };
+    __extension__ char val[] = { [0 ... COMMANDER_REPORT_SIZE] = '1' };
     commander_clear_report();
     commander_fill_report_len("testing", val, SUCCESS, COMMANDER_REPORT_SIZE / 2);
     commander_fill_report_len("testing", val, SUCCESS, COMMANDER_REPORT_SIZE / 2);

--- a/src/memory.c
+++ b/src/memory.c
@@ -85,8 +85,8 @@ void memory_setup(void)
 void memory_erase(void)
 {
     memory_mempass();
-    memory_write_aeskey((char *)MEM_PAGE_ERASE, MEM_PAGE_LEN, PASSWORD_STAND);
-    memory_write_aeskey((char *)MEM_PAGE_ERASE, MEM_PAGE_LEN, PASSWORD_CRYPT);
+    memory_write_aeskey((const char *)MEM_PAGE_ERASE, MEM_PAGE_LEN, PASSWORD_STAND);
+    memory_write_aeskey((const char *)MEM_PAGE_ERASE, MEM_PAGE_LEN, PASSWORD_CRYPT);
     memory_mnemonic(MEM_PAGE_ERASE_2X);
     memory_chaincode(MEM_PAGE_ERASE);
     memory_master(MEM_PAGE_ERASE);
@@ -267,9 +267,9 @@ uint8_t *memory_chaincode(const uint8_t *chain)
 uint16_t *memory_mnemonic(const uint16_t *idx)
 {
     if (idx) {
-        memory_eeprom_crypt((uint8_t *)idx, (uint8_t *)MEM_mnemonic_,
+        memory_eeprom_crypt((const uint8_t *)idx, (uint8_t *)MEM_mnemonic_,
                             MEM_MNEMONIC_BIP32_ADDR_0);
-        memory_eeprom_crypt((uint8_t *)idx + MEM_PAGE_LEN,
+        memory_eeprom_crypt((const uint8_t *)idx + MEM_PAGE_LEN,
                             (uint8_t *)MEM_mnemonic_ + MEM_PAGE_LEN,
                             MEM_MNEMONIC_BIP32_ADDR_1);
     } else {
@@ -285,7 +285,7 @@ uint16_t *memory_mnemonic(const uint16_t *idx)
 int memory_aeskey_is_erased(PASSWORD_ID id)
 {
     uint8_t mem_aeskey_erased[MEM_PAGE_LEN];
-    sha256_Raw((uint8_t *)MEM_PAGE_ERASE, MEM_PAGE_LEN, mem_aeskey_erased);
+    sha256_Raw((const uint8_t *)MEM_PAGE_ERASE, MEM_PAGE_LEN, mem_aeskey_erased);
     sha256_Raw(mem_aeskey_erased, MEM_PAGE_LEN, mem_aeskey_erased);
 
     if (memcmp(memory_read_aeskey(id), mem_aeskey_erased, 32)) {
@@ -318,7 +318,7 @@ int memory_write_aeskey(const char *password, int len, PASSWORD_ID id)
         return ERROR;
     }
 
-    sha256_Raw((uint8_t *)password, len, password_b);
+    sha256_Raw((const uint8_t *)password, len, password_b);
     sha256_Raw(password_b, MEM_PAGE_LEN, password_b);
 
     switch ((int)id) {
@@ -409,7 +409,8 @@ uint8_t memory_read_erased(void)
 
 void memory_write_touch_timeout(const uint16_t t)
 {
-    memory_eeprom((uint8_t *)&t, (uint8_t *)&MEM_touch_timeout_, MEM_TOUCH_TIMEOUT_ADDR, 2);
+    memory_eeprom((const uint8_t *)&t, (uint8_t *)&MEM_touch_timeout_, MEM_TOUCH_TIMEOUT_ADDR,
+                  2);
 }
 uint16_t memory_read_touch_timeout(void)
 {
@@ -420,7 +421,8 @@ uint16_t memory_read_touch_timeout(void)
 
 void memory_write_touch_thresh(const uint16_t t)
 {
-    memory_eeprom((uint8_t *)&t, (uint8_t *)&MEM_touch_thresh_, MEM_TOUCH_THRESH_ADDR, 2);
+    memory_eeprom((const uint8_t *)&t, (uint8_t *)&MEM_touch_thresh_, MEM_TOUCH_THRESH_ADDR,
+                  2);
 }
 uint16_t memory_read_touch_thresh(void)
 {

--- a/src/memory.c
+++ b/src/memory.c
@@ -49,18 +49,18 @@ static uint16_t MEM_access_err_ = DEFAULT_access_err_;
 static uint16_t MEM_touch_thresh_ = DEFAULT_touch_timeout_;
 static uint16_t MEM_touch_timeout_ = DEFAULT_touch_timeout_;
 
-static uint8_t MEM_aeskey_2FA_[] = {[0 ... MEM_PAGE_LEN] = 0xFF};
-static uint8_t MEM_aeskey_stand_[] = {[0 ... MEM_PAGE_LEN] = 0xFF};
-static uint8_t MEM_aeskey_crypt_[] = {[0 ... MEM_PAGE_LEN] = 0xFF};
-static uint8_t MEM_aeskey_verify_[] = {[0 ... MEM_PAGE_LEN] = 0xFF};
-static uint8_t MEM_aeskey_memory_[] = {[0 ... MEM_PAGE_LEN] = 0xFF};
-static uint8_t MEM_name_[] = {[0 ... MEM_PAGE_LEN] = '0'};
-static uint8_t MEM_master_[] = {[0 ... MEM_PAGE_LEN] = 0xFF};
-static uint8_t MEM_master_chain_[] = {[0 ... MEM_PAGE_LEN] = 0xFF};
-static uint16_t MEM_mnemonic_[] = {[0 ... MEM_PAGE_LEN] = 0xFFFF};
+__extension__ static uint8_t MEM_aeskey_2FA_[] = {[0 ... MEM_PAGE_LEN] = 0xFF};
+__extension__ static uint8_t MEM_aeskey_stand_[] = {[0 ... MEM_PAGE_LEN] = 0xFF};
+__extension__ static uint8_t MEM_aeskey_crypt_[] = {[0 ... MEM_PAGE_LEN] = 0xFF};
+__extension__ static uint8_t MEM_aeskey_verify_[] = {[0 ... MEM_PAGE_LEN] = 0xFF};
+__extension__ static uint8_t MEM_aeskey_memory_[] = {[0 ... MEM_PAGE_LEN] = 0xFF};
+__extension__ static uint8_t MEM_name_[] = {[0 ... MEM_PAGE_LEN] = '0'};
+__extension__ static uint8_t MEM_master_[] = {[0 ... MEM_PAGE_LEN] = 0xFF};
+__extension__ static uint8_t MEM_master_chain_[] = {[0 ... MEM_PAGE_LEN] = 0xFF};
+__extension__ static uint16_t MEM_mnemonic_[] = {[0 ... MEM_PAGE_LEN] = 0xFFFF};
 
-const uint8_t MEM_PAGE_ERASE[] = {[0 ... MEM_PAGE_LEN] = 0xFF};
-const uint16_t MEM_PAGE_ERASE_2X[] = {[0 ... MEM_PAGE_LEN] = 0xFFFF};
+__extension__ const uint8_t MEM_PAGE_ERASE[] = {[0 ... MEM_PAGE_LEN] = 0xFF};
+__extension__ const uint16_t MEM_PAGE_ERASE_2X[] = {[0 ... MEM_PAGE_LEN] = 0xFFFF};
 
 
 // One-time setup on factory install

--- a/src/sha2.c
+++ b/src/sha2.c
@@ -507,7 +507,7 @@ void sha256_Update(SHA256_CTX *context, const sha2_byte *data, size_t len)
     }
     while (len >= SHA256_BLOCK_LENGTH) {
         /* Process as many complete blocks as we can */
-        sha256_Transform(context, (sha2_word32 *)data);
+        sha256_Transform(context, (const sha2_word32 *)data);
         context->bitcount += SHA256_BLOCK_LENGTH << 3;
         len -= SHA256_BLOCK_LENGTH;
         data += SHA256_BLOCK_LENGTH;
@@ -835,7 +835,7 @@ void sha512_Update(SHA512_CTX *context, const sha2_byte *data, size_t len)
     }
     while (len >= SHA512_BLOCK_LENGTH) {
         /* Process as many complete blocks as we can */
-        sha512_Transform(context, (sha2_word64 *)data);
+        sha512_Transform(context, (const sha2_word64 *)data);
         ADDINC128(context->bitcount, SHA512_BLOCK_LENGTH << 3);
         len -= SHA512_BLOCK_LENGTH;
         data += SHA512_BLOCK_LENGTH;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,5 @@
 include_directories(../src)
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-cast-qual")
-
 #-----------------------------------------------------------------------------
 # Build tests_unit
 add_executable(tests_unit tests_unit.c)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 include_directories(../src)
 
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-cast-qual")
 
 #-----------------------------------------------------------------------------
 # Build tests_unit

--- a/tests/tests_unit.c
+++ b/tests/tests_unit.c
@@ -439,7 +439,7 @@ static void test_bip32_vector_2(void)
 
 
 #define test_deterministic(KEY, MSG, K) do { \
-    sha256_Raw((uint8_t *)MSG, strlen(MSG), buf); \
+    sha256_Raw((const uint8_t *)MSG, strlen(MSG), buf); \
     res = generate_k_rfc6979_test(k, utils_hex_to_uint8(KEY), buf); \
     u_assert_int_eq(res, 0); \
     u_assert_mem_eq(k, utils_hex_to_uint8(K), 32); \
@@ -600,25 +600,26 @@ static void test_pbkdf2_hmac_sha256(void)
     uint8_t k[40], s[40];
 
     strcpy((char *)s, "salt");
-    pbkdf2_hmac_sha256((uint8_t *)"password", 8, s, 4, 1, k, 32, 0);
+    pbkdf2_hmac_sha256((const uint8_t *)"password", 8, s, 4, 1, k, 32, 0);
     u_assert_mem_eq(k,
                     utils_hex_to_uint8("120fb6cffcf8b32c43e7225256c4f837a86548c92ccc35480805987cb70be17b"),
                     32);
 
     strcpy((char *)s, "salt");
-    pbkdf2_hmac_sha256((uint8_t *)"password", 8, s, 4, 2, k, 32, 0);
+    pbkdf2_hmac_sha256((const uint8_t *)"password", 8, s, 4, 2, k, 32, 0);
     u_assert_mem_eq(k,
                     utils_hex_to_uint8("ae4d0c95af6b46d32d0adff928f06dd02a303f8ef3c251dfd6e2d85a95474c43"),
                     32);
 
     strcpy((char *)s, "salt");
-    pbkdf2_hmac_sha256((uint8_t *)"password", 8, s, 4, 4096, k, 32, 0);
+    pbkdf2_hmac_sha256((const uint8_t *)"password", 8, s, 4, 4096, k, 32, 0);
     u_assert_mem_eq(k,
                     utils_hex_to_uint8("c5e478d59288c841aa530db6845c4c8d962893a001ce4e11a4963873aa98134a"),
                     32);
 
     strcpy((char *)s, "saltSALTsaltSALTsaltSALTsaltSALTsalt");
-    pbkdf2_hmac_sha256((uint8_t *)"passwordPASSWORDpassword", 3 * 8, s, 9 * 4, 4096, k, 64,
+    pbkdf2_hmac_sha256((const uint8_t *)"passwordPASSWORDpassword", 3 * 8, s, 9 * 4, 4096, k,
+                       64,
                        0);
     u_assert_mem_eq(k,
                     utils_hex_to_uint8("348c89dbcbd32b2f32d814b8116e84cf2b17347ebc1800181c4e2a1fb8dd53e1c635518c7dac47e9"),
@@ -631,25 +632,26 @@ static void test_pbkdf2_hmac_sha512(void)
     uint8_t k[64], s[40];
 
     strcpy((char *)s, "salt");
-    pbkdf2_hmac_sha512((uint8_t *)"password", 8, s, 4, 1, k, 64, 0);
+    pbkdf2_hmac_sha512((const uint8_t *)"password", 8, s, 4, 1, k, 64, 0);
     u_assert_mem_eq(k,
                     utils_hex_to_uint8("867f70cf1ade02cff3752599a3a53dc4af34c7a669815ae5d513554e1c8cf252c02d470a285a0501bad999bfe943c08f050235d7d68b1da55e63f73b60a57fce"),
                     64);
 
     strcpy((char *)s, "salt");
-    pbkdf2_hmac_sha512((uint8_t *)"password", 8, s, 4, 2, k, 64, 0);
+    pbkdf2_hmac_sha512((const uint8_t *)"password", 8, s, 4, 2, k, 64, 0);
     u_assert_mem_eq(k,
                     utils_hex_to_uint8("e1d9c16aa681708a45f5c7c4e215ceb66e011a2e9f0040713f18aefdb866d53cf76cab2868a39b9f7840edce4fef5a82be67335c77a6068e04112754f27ccf4e"),
                     64);
 
     strcpy((char *)s, "salt");
-    pbkdf2_hmac_sha512((uint8_t *)"password", 8, s, 4, 4096, k, 64, 0);
+    pbkdf2_hmac_sha512((const uint8_t *)"password", 8, s, 4, 4096, k, 64, 0);
     u_assert_mem_eq(k,
                     utils_hex_to_uint8("d197b1b33db0143e018b12f3d1d1479e6cdebdcc97c5c0f87f6902e072f457b5143f30602641b3d55cd335988cb36b84376060ecd532e039b742a239434af2d5"),
                     64);
 
     strcpy((char *)s, "saltSALTsaltSALTsaltSALTsaltSALTsalt");
-    pbkdf2_hmac_sha512((uint8_t *)"passwordPASSWORDpassword", 3 * 8, s, 9 * 4, 4096, k, 64,
+    pbkdf2_hmac_sha512((const uint8_t *)"passwordPASSWORDpassword", 3 * 8, s, 9 * 4, 4096, k,
+                       64,
                        0);
     u_assert_mem_eq(k,
                     utils_hex_to_uint8("8c0511f4c6e597c6ac6315d8f0362e225f3c501495ba23b868c005174dc4ee71115b59f9e60cd9532fa33e0f75aefe30225c583a186cd82bd4daea9724a3d3b8"),


### PR DESCRIPTION
I've deactivated -Wcast-qual in the tests folder for now (it triggered a lot of warnings in the  trezor code).