### PR TITLE
Git: Add astyle commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,13 @@ Please do *NOT* use an editor that automatically reformats.
 
 Use the coding style set by astyle (http://astyle.sourceforge.net/) with the following parameteres:
 > astyle --style=stroustrup --indent-switches --indent-labels --pad-oper --pad-header --align-pointer=name --add-brackets --convert-tabs --max-code-length=90 --break-after-logical --suffix=none *.c *.h --recursive
+
+
+#### astyle Git hook
+
+For convenience please enable the git hooks which will trigger astyle each time you commit.
+To do so type in the repo directory:
+
+    cd .git/hooks
+    ln -s ../../contrib/git/pre-commit
+

--- a/contrib/git/pre-commit
+++ b/contrib/git/pre-commit
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+hasFormattingIssues=0
+
+if ! command -v astyle >/dev/null ; then
+    echo -n "error: please install astyle in order to be able"
+    echo    " to use this pre-commit git-hook"
+    exit 1
+fi
+
+if git rev-parse --verify HEAD >/dev/null 2>&1; then
+    against=HEAD
+else
+    # Initial commit: diff against an empty tree object
+    against=2caab4551b305ab1e9e4b05145a4da5f51331e0d
+fi
+
+# Redirect output to stderr.
+exec 1>&2
+
+files=$(git diff --cached --name-only --diff-filter=AM $against | \
+        grep -E '^(src|tests)' | grep -E '(c|h)$')
+        
+for file in $files; do
+    astyle --style=stroustrup --indent-switches --indent-labels --pad-oper --pad-header --align-pointer=name --add-brackets --convert-tabs --max-code-length=90 --break-after-logical -Q $file
+    if [ -e "$file.orig" ]; then
+        mv $file "$file.formated"
+        mv "$file.orig" $file
+        git diff --no-index "$file" "$file.formated" | cat
+
+        isDiff=$(diff --brief "$file.formated" $file)
+        if [ "$isDiff" != "" ] ; then
+            hasFormattingIssues=1
+        fi
+        rm "$file.formated"
+    fi
+done
+
+
+if  [ $hasFormattingIssues -eq 1 ]  ; then
+    echo Found code style formatting issues.
+    exit 1
+fi


### PR DESCRIPTION
This way you don't have to wait for Travis to know about coding style issues.

Has to be activated manually on client side (as described in README.md).