### PR TITLE
utest: Add stdio.h and string.h includes

### DIFF
--- a/tests/utest.h
+++ b/tests/utest.h
@@ -76,6 +76,8 @@
 #ifndef _UTEST_H_
 #define _UTEST_H_
 
+#include <stdio.h>
+#include <string.h>
 
 #define u_run_test(TEST) do {\
  int f_ = U_TESTS_FAIL; \


### PR DESCRIPTION
Got an error when I tried to use utest.h in the bitbox-client library because of those missing includes (here included by tests_unit.c).