### PR TITLE
test_api: Fix cast-qual in HID tests

### DIFF
--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -98,7 +98,7 @@ static void api_hid_send(const char *cmd)
 static void api_hid_send_encrypt(const char *cmd)
 {
     int enc_len;
-    char *enc = aes_cbc_b64_encrypt((unsigned char *)cmd, strlen(cmd), &enc_len,
+    char *enc = aes_cbc_b64_encrypt((const unsigned char *)cmd, strlen(cmd), &enc_len,
                                     PASSWORD_STAND);
     api_hid_send_len(enc, enc_len);
     free(enc);


### PR DESCRIPTION
Doesn't get catch by Travis because it's in the #ifndef CONTINUOUS_INTEGRATION part.