### PR TITLE
fix osx linker flags for libhidapi, mention it in README.md

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W -Wall -Wextra -Werror -pedantic -Wredunda
 
 if(APPLE)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations")
+  set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -framework AppKit -framework IOKit")
   set(CMAKE_MACOSX_RPATH ON)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ ECDSA signatures are performed using a simplified version of the [micro ECC libr
 
 
 ## Build Instructions
+Dependencies:
+
+- https://github.com/signal11/hidapi
+
+OSX:
+
+    brew install hidapi
+
+--------------
+
 Basic build steps:
 
     mkdir build


### PR DESCRIPTION
While building i stepped over this.
Maybe it would be worth to add https://github.com/signal11/hidapi as submodule and somehow included in the the CMake process?