### PR TITLE
overwrite (secure erase) files before f_unlink in 'erase' command

### DIFF
--- a/src/sd.c
+++ b/src/sd.c
@@ -284,23 +284,23 @@ uint8_t sd_erase(void)
                 continue;
             }
 
-			char file[256] = {0};
-			memcpy(file, "0:", 2);
-			memcpy(file + 2, pc_fn, (strlen(pc_fn) < 256 - 2) ? strlen(pc_fn) : 256 - 2);
+            char file[256] = {0};
+            memcpy(file, "0:", 2);
+            memcpy(file + 2, pc_fn, (strlen(pc_fn) < 256 - 2) ? strlen(pc_fn) : 256 - 2);
 
-			FIL file_object;
-			file[0] = LUN_ID_SD_MMC_0_MEM + '0';
-			res = f_open(&file_object, (char const *)file, FA_OPEN_EXISTING | FA_WRITE);
-			if (res != FR_OK) {
-				commander_fill_report("sd_erase", FLAG_ERR_SD_OPEN, ERROR);
-				failed = 1;
-				break;
-			}
+            FIL file_object;
+            file[0] = LUN_ID_SD_MMC_0_MEM + '0';
+            res = f_open(&file_object, (char const *)file, FA_OPEN_EXISTING | FA_WRITE);
+            if (res != FR_OK) {
+                commander_fill_report("sd_erase", FLAG_ERR_SD_OPEN, ERROR);
+                failed = 1;
+                break;
+            }
 
-			DWORD f_ps, fsize = file_object.fsize;
-			for (f_ps = 0; f_ps < fsize; f_ps++) {
-				f_putc(0xAC, &file_object); // overwrite data
-			}
+            DWORD f_ps, fsize = file_object.fsize;
+            for (f_ps = 0; f_ps < fsize; f_ps++) {
+                f_putc(0xAC, &file_object); // overwrite data
+            }
 
             if (f_unlink(pc_fn) != FR_OK) {
                 failed++;
@@ -312,8 +312,8 @@ uint8_t sd_erase(void)
     f_mount(LUN_ID_SD_MMC_0_MEM, NULL);
 
     if (failed) {
-	    commander_fill_report("sd_erase", FLAG_ERR_SD_NO_FILE, ERROR);
-	    return ERROR;
+        commander_fill_report("sd_erase", FLAG_ERR_SD_NO_FILE, ERROR);
+        return ERROR;
     } else {
         commander_fill_report("sd_erase", "success", SUCCESS);
         return SUCCESS;


### PR DESCRIPTION
Currently, files that are to be erased on the micro SD card are unlinked (f_unlink). The data remains and could be recovered. This update will wipe file contents before f_unlink is performed, and also return error messages if something goes wrong. 