### PR TITLE
Independent entropy to RNG

### DIFF
--- a/src/random.c
+++ b/src/random.c
@@ -54,6 +54,7 @@ int random_bytes(uint8_t *buf, uint32_t len, uint8_t update_seed)
 #else
 
 #include "ataes132.h"
+#include "memory.h"
 
 void random_init(void) { };
 int random_bytes(uint8_t *buf, uint32_t len, uint8_t update_seed)
@@ -77,6 +78,13 @@ int random_bytes(uint8_t *buf, uint32_t len, uint8_t update_seed)
         }
         cnt += 16;
     }
+
+    // add ataes independent entropy
+    uint8_t *entropy = memory_read_aeskey(PASSWORD_MEMORY);
+    for (uint32_t i = 0; i < len; i++) {
+        buf[i] = buf[i] ^ entropy[i % MEM_PAGE_LEN];
+    }
+
     return SUCCESS;
 }
 

--- a/src/sd.c
+++ b/src/sd.c
@@ -231,7 +231,7 @@ uint8_t sd_list(void)
 
 err:
     memset(files, 0, sizeof(files));
-    return NULL;
+    return ERROR;
 
 }
 
@@ -239,7 +239,7 @@ err:
 
 uint8_t sd_erase(void)
 {
-    int erased = 0;
+    int failed = 0;
     FILINFO fno;
     DIR dir;
     const char *path = "0:";

--- a/src/sd.c
+++ b/src/sd.c
@@ -231,7 +231,7 @@ uint8_t sd_list(void)
 
 err:
     memset(files, 0, sizeof(files));
-    return 0;
+    return NULL;
 
 }
 
@@ -239,7 +239,7 @@ err:
 
 uint8_t sd_erase(void)
 {
-    int failed = 0;
+    int erased = 0;
     FILINFO fno;
     DIR dir;
     const char *path = "0:";
@@ -284,38 +284,21 @@ uint8_t sd_erase(void)
                 continue;
             }
 
-			char file[256] = {0};
-			memcpy(file, "0:", 2);
-			memcpy(file + 2, pc_fn, (strlen(pc_fn) < 256 - 2) ? strlen(pc_fn) : 256 - 2);
-
-			FIL file_object;
-			file[0] = LUN_ID_SD_MMC_0_MEM + '0';
-			res = f_open(&file_object, (char const *)file, FA_OPEN_EXISTING | FA_WRITE);
-			if (res != FR_OK) {
-				commander_fill_report("sd_erase", FLAG_ERR_SD_OPEN, ERROR);
-				failed = 1;
-				break;
-			}
-
-			DWORD f_ps, fsize = file_object.fsize;
-			for (f_ps = 0; f_ps < fsize; f_ps++) {
-				f_putc(0xAC, &file_object); // overwrite data
-			}
-
-            if (f_unlink(pc_fn) != FR_OK) {
-                failed++;
+            if (f_unlink(pc_fn) == FR_OK) {
+                erased++;
             }
+
         }
     }
 
     // Unmount
     f_mount(LUN_ID_SD_MMC_0_MEM, NULL);
 
-    if (failed) {
-	    commander_fill_report("sd_erase", FLAG_ERR_SD_NO_FILE, ERROR);
-	    return ERROR;
-    } else {
+    if (erased) {
         commander_fill_report("sd_erase", "success", SUCCESS);
         return SUCCESS;
+    } else {
+        commander_fill_report("sd_erase", FLAG_ERR_SD_NO_FILE, ERROR);
+        return ERROR;
     }
 }

--- a/src/sd.c
+++ b/src/sd.c
@@ -305,7 +305,6 @@ uint8_t sd_erase(void)
             if (f_unlink(pc_fn) != FR_OK) {
                 failed++;
             }
-
         }
     }
 


### PR DESCRIPTION
To remove some of the trust required for the ATAES hardware random number generator, one can add entropy from an independent source using bitwise xor ([proof](http://crypto.stackexchange.com/questions/17658/mixing-entropy-sources-by-xor)). 

In this update, the random number returned by the hardware RNG is xor'd with a double SHA hash of random parts of the machine code, as gathered [here](https://github.com/dbitbox/mcu/blob/master/src/memory.c#L236-L258).
