### PR TITLE
Autobackup on seed

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -451,6 +451,7 @@ static void commander_process_seed(yajl_val json_node)
         return;
     }
 
+    commander_clear_report();
     commander_fill_report("seed", "success", SUCCESS);
 }
 

--- a/src/commander.h
+++ b/src/commander.h
@@ -43,6 +43,8 @@
 #define VERIFYPASS_FILENAME     "verification.txt"
 #define COMMANDER_MAX_ATTEMPTS  5// max attempts before device reset
 
+#define AUTOBACKUP_FILENAME     "autobackup.aes"
+#define AUTOBACKUP_ENCRYPT      "yes"
 
 char *aes_cbc_b64_encrypt(const unsigned char *in, int inlen, int *out_b64len,
                           PASSWORD_ID id);

--- a/src/flags.h
+++ b/src/flags.h
@@ -140,6 +140,7 @@ enum REPORT_FLAGS {
 #define FLAG_ERR_KEY_GEN            "Could not generate key."
 #define FLAG_ERR_SIGN               "Could not sign."
 #define FLAG_ERR_SALT_LEN           "Salt must be less than " STRINGIFY(SALT_LEN_MAX) " characters."
+#define FLAG_ERR_SEED_SD            "Seed creation requires an SD card for automatic encrypted backup of the seed."
 #define FLAG_ERR_SEED_MEM           "Could not allocate memory for seed."
 #define FLAG_ERR_ENCRYPT_MEM        "Could not encrypt."
 #define FLAG_ERR_ATAES              "Chip communication error."

--- a/src/memory.c
+++ b/src/memory.c
@@ -82,14 +82,20 @@ void memory_setup(void)
 }
 
 
+void memory_erase_seed(void)
+{
+    memory_mnemonic(MEM_PAGE_ERASE_2X);
+    memory_chaincode(MEM_PAGE_ERASE);
+    memory_master(MEM_PAGE_ERASE);
+}
+
+
 void memory_erase(void)
 {
     memory_mempass();
     memory_write_aeskey((const char *)MEM_PAGE_ERASE, MEM_PAGE_LEN, PASSWORD_STAND);
     memory_write_aeskey((const char *)MEM_PAGE_ERASE, MEM_PAGE_LEN, PASSWORD_CRYPT);
-    memory_mnemonic(MEM_PAGE_ERASE_2X);
-    memory_chaincode(MEM_PAGE_ERASE);
-    memory_master(MEM_PAGE_ERASE);
+    memory_erase_seed();
     memory_name("Digital Bitbox");
     memory_write_erased(DEFAULT_erased_);
     memory_write_unlocked(DEFAULT_unlocked_);

--- a/src/memory.h
+++ b/src/memory.h
@@ -71,6 +71,7 @@ typedef enum PASSWORD_ID {
 
 
 void memory_erase(void);
+void memory_erase_seed(void);
 void memory_setup(void);
 void memory_clear_variables(void);
 void memory_mempass(void);


### PR DESCRIPTION
To avoid a novice user from forgetting to create a backup, require its creation for the `seed: create` command. This requires a micro SD card to be present.

The alternative 2 methods of seeding from an existing micro SD backup file or as input via the USB are not affected.

One question: should the automatic backup be encrypted or not? It is encrypted in this pull request, with the AES encryption key being the same as used to send commands to the device via the USB interface.

 