### PR TITLE
return on invalid input (empty string)

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -591,6 +591,7 @@ static void commander_process_xpub(yajl_val json_node)
 
     if (!value || !strlens(value)) {
         commander_fill_report("xpub", FLAG_ERR_INVALID_CMD, ERROR);
+        return;
     }
 
     wallet_report_xpub(value, strlens(value), xpub);


### PR DESCRIPTION
`xpub` command to get public keys. An empty string should get treated as an error. Simple one line commit, so I will just merge it right away.