### PR TITLE
use git version tag as dbb version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(mcu)
 
 find_package(Git)
 if(GIT_FOUND)
-  execute_process(COMMAND git "rev-parse" "HEAD" OUTPUT_VARIABLE GIT_COMMIT_HASH WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process(COMMAND git "rev-parse" "--short" "HEAD" OUTPUT_VARIABLE GIT_COMMIT_HASH WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} OUTPUT_STRIP_TRAILING_WHITESPACE)
 else()
   set(GIT_COMMIT_HASH "Git not found.")
 endif()
@@ -11,18 +11,15 @@ endif()
 set(VERSION_MAJOR  1)
 set(VERSION_MINOR  0)
 set(VERSION_BUGFIX 0)
-set(VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUGFIX}")
+set(VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUGFIX} (${GIT_COMMIT_HASH})")
 
 #-----------------------------------------------------------------------------
 # Options for building
 
-option(BUILD_VERBOSE       "Verbose build output." ON)
 option(BUILD_TESTS         "Build the unit tests." ON)
 #option(BUILD_DOCUMENTATION "Build the Doxygen documentation." ON)
 
-if(BUILD_VERBOSE)
-  set(CMAKE_VERBOSE_MAKEFILE true)
-endif()
+set(CMAKE_VERBOSE_MAKEFILE ON)
 
 
 #-----------------------------------------------------------------------------
@@ -35,7 +32,7 @@ message(STATUS "CMake version:          ${CMAKE_VERSION}")
 message(STATUS "System:                 ${CMAKE_SYSTEM}")
 message(STATUS "Processor:              ${CMAKE_SYSTEM_PROCESSOR}")
 
-message(STATUS "Verbose:                ${BUILD_VERBOSE}")
+message(STATUS "Verbose:                ${CMAKE_VERBOSE_MAKEFILE}")
 message(STATUS "Testing:                ${BUILD_TESTS}")
 #message(STATUS "Documentation:          ${BUILD_DOCUMENTATION}")
 
@@ -158,6 +155,8 @@ endif()
 if(BUILD_TESTS)
   add_definitions(-DTESTING)
 endif()
+
+add_definitions(-DGIT_VERSION="${VERSION_STRING}")
 
 
 #-----------------------------------------------------------------------------

--- a/src/commander.h
+++ b/src/commander.h
@@ -39,7 +39,7 @@
 #else
 #define COMMANDER_REPORT_SIZE   2048
 #endif
-#define DIGITAL_BITBOX_VERSION  "1.0"
+#define DIGITAL_BITBOX_VERSION  GIT_VERSION
 #define VERIFYPASS_FILENAME     "verification.txt"
 #define COMMANDER_MAX_ATTEMPTS  5// max attempts before device reset
 


### PR DESCRIPTION
Automatically use the Git version string + hash as the dbb version string. Example output:

```
$ bin/tests_cmdline '{"device":"version"}'

utils send:   {"password":"standard_password"}
utils recv:   { "password": "success" }


utils send:   {"device":"version"}
utils recv:   /* ciphertext */ { "version": "1.0.0 (ab96b299c7d07e65d77e0262f09bf2a33f44eb4f)" }
```

(This commit also makes the default compilation not verbose.)