### PR TITLE
fixes from live testing

### DIFF
--- a/src/sd.c
+++ b/src/sd.c
@@ -79,7 +79,7 @@ uint8_t sd_write(const char *f, uint16_t f_len, const char *t, uint16_t t_len,
     f_mkdir(ROOTDIR);
 
     res = f_open(&file_object, (char const *)file,
-                 (replace == REPLACE ? FA_OPEN_EXISTING : FA_CREATE_NEW) | FA_WRITE);
+                 (replace == REPLACE ? FA_CREATE_ALWAYS : FA_CREATE_NEW) | FA_WRITE);
     if (res != FR_OK) {
         commander_fill_report("sd_write", FLAG_ERR_SD_OPEN, ERROR);
         f_mount(LUN_ID_SD_MMC_0_MEM, NULL);

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -583,7 +583,8 @@ static void tests_device(void)
     if (api_result_has("error")) {
         goto err;
     }
-    if (!api_result_has(DIGITAL_BITBOX_VERSION)) {
+    //if (!api_result_has(DIGITAL_BITBOX_VERSION)) {
+    if (!api_result_has("version\":")) {
         goto err;
     }
 
@@ -804,11 +805,7 @@ static void tests_echo_2FA(void)
     if ( api_result_has("error"))              {
         goto err;
     }
-    api_format_send_cmd("verifypass", export, PASSWORD_STAND);
-    if (!api_result_has(FLAG_ERR_SD_OPEN) &&
-            !api_result_has(FLAG_ERR_NO_MCU))      {
-        goto err;
-    }
+
     api_format_send_cmd("backup", "list", PASSWORD_STAND);
     if (!api_result_has(VERIFYPASS_FILENAME))  {
         goto err;


### PR DESCRIPTION
Simple update after doing live testing:

- Overwriting files on microSD needs FA_CREATE_ALWAYS flag instead of 	FA_OPEN_EXISTNG.
- `tests_api.c` corrected checks - no longer have an error when overwrite verification key on SD card; different devices may have different version strings, so don't check for an exact version match.