### PR TITLE
pull version numbers from latest git tag; use version files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,22 @@
 cmake_minimum_required(VERSION 2.8)
 project(mcu)
 
+
+#-----------------------------------------------------------------------------
+# Create version header file
+
 find_package(Git)
 if(GIT_FOUND)
-  execute_process(COMMAND git "rev-parse" "--short" "HEAD" OUTPUT_VARIABLE GIT_COMMIT_HASH WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} OUTPUT_STRIP_TRAILING_WHITESPACE)
+  execute_process(COMMAND git "describe" "--tags" OUTPUT_VARIABLE GIT_COMMIT_HASH WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} OUTPUT_STRIP_TRAILING_WHITESPACE)
 else()
   set(GIT_COMMIT_HASH "Git not found.")
 endif()
+set(VERSION_STRING "${GIT_COMMIT_HASH}")
 
-set(VERSION_MAJOR  1)
-set(VERSION_MINOR  0)
-set(VERSION_BUGFIX 0)
-set(VERSION_STRING "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_BUGFIX} (${GIT_COMMIT_HASH})")
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/version.h.in
+               ${CMAKE_CURRENT_SOURCE_DIR}/src/version.h)
+set(version_file "${CMAKE_CURRENT_SOURCE_DIR}/src/version.h")
+
 
 #-----------------------------------------------------------------------------
 # Options for building
@@ -155,8 +160,6 @@ endif()
 if(BUILD_TESTS)
   add_definitions(-DTESTING)
 endif()
-
-add_definitions(-DGIT_VERSION="${VERSION_STRING}")
 
 
 #-----------------------------------------------------------------------------

--- a/src/commander.c
+++ b/src/commander.c
@@ -31,6 +31,7 @@
 
 #include "yajl/src/api/yajl_tree.h"
 #include "commander.h"
+#include "version.h"
 #include "random.h"
 #include "memory.h"
 #include "base64.h"

--- a/src/commander.h
+++ b/src/commander.h
@@ -39,7 +39,6 @@
 #else
 #define COMMANDER_REPORT_SIZE   2048
 #endif
-#define DIGITAL_BITBOX_VERSION  GIT_VERSION
 #define VERIFYPASS_FILENAME     "verification.txt"
 #define COMMANDER_MAX_ATTEMPTS  5// max attempts before device reset
 

--- a/src/version.h
+++ b/src/version.h
@@ -1,0 +1,6 @@
+#ifndef VERSION_H
+#define VERSION_H
+
+const char *DIGITAL_BITBOX_VERSION = "v1.0.2-6-g11762df";
+
+#endif

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -1,0 +1,6 @@
+#ifndef VERSION_H
+#define VERSION_H
+
+const char *DIGITAL_BITBOX_VERSION = "@VERSION_STRING@";
+
+#endif

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -583,7 +583,6 @@ static void tests_device(void)
     if (api_result_has("error")) {
         goto err;
     }
-    //if (!api_result_has(DIGITAL_BITBOX_VERSION)) {
     if (!api_result_has("version\":")) {
         goto err;
     }


### PR DESCRIPTION
Pull version values from latest tag on git using `git describe --tags` instead of hardcoded in cmake file. The version string will look like:
```
$ git describe --tags
v1.0.2-6-g11762df
```

Put the version into a file instead of a makefile `-D` compilation flag.

(Also removed commented line in `tests_api.c`)