### PR TITLE
restart signing verification process if non-sign command is entered

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -983,8 +983,13 @@ static int commander_touch_button(int found_cmd, yajl_val json_node)
             memset(verify_output, 0, COMMANDER_REPORT_SIZE);
             return STATUS_ERROR;
         }
+    }
 
-    } else if (found_cmd == CMD_seed_ && !memcmp(memory_master(NULL), MEM_PAGE_ERASE, 32)) {
+    // Reset if not sign command
+    memset(verify_input, 0, COMMANDER_REPORT_SIZE);
+    memset(verify_output, 0, COMMANDER_REPORT_SIZE);
+
+    if (found_cmd == CMD_seed_ && !memcmp(memory_master(NULL), MEM_PAGE_ERASE, 32)) {
         return STATUS_TOUCHED;
     } else if (found_cmd < CMD_require_touch_) {
         return (touch_button_press(0));

--- a/src/version.h
+++ b/src/version.h
@@ -1,6 +1,6 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-const char *DIGITAL_BITBOX_VERSION = "v1.0.2-7-g1f9ef5f";
+const char *DIGITAL_BITBOX_VERSION = "v1.0.2-9-g928953b";
 
 #endif


### PR DESCRIPTION
Signing verification process is currently to send sign command twice. First returns an encrypted 'echo' used for 2FA verification. The second will process the command if the touch button is held. This pull request restarts this process if a different command is input before the second sign command.