### PR TITLE
Fix cmake submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ message(STATUS "C link flags:  ${CMAKE_C_LINK_FLAGS}")
 #-----------------------------------------------------------------------------
 # Get submodules
 
-#execute_process(COMMAND git "submodule" "update" "--init" "--recursive" WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+execute_process(COMMAND git "submodule" "update" "--init" "--recursive" WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 
 #-----------------------------------------------------------------------------


### PR DESCRIPTION
First commit reactivates the git submodule initialization (EDIT: so users don't have to do anything manually other than cmake .. && make).

Second one sets the version.h file to .gitignore, since it gets generate everytime someone builds the file and is outdated everytime one makes a new commit.