### PR TITLE
remove touch button parameters from eeprom memory

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -46,8 +46,6 @@ static uint8_t MEM_unlocked_ = DEFAULT_unlocked_;
 static uint8_t MEM_erased_ = DEFAULT_erased_;
 static uint8_t MEM_setup_ = DEFAULT_setup_;
 static uint16_t MEM_access_err_ = DEFAULT_access_err_;
-static uint16_t MEM_touch_thresh_ = DEFAULT_touch_thresh_;
-static uint16_t MEM_touch_timeout_ = DEFAULT_touch_timeout_;
 
 __extension__ static uint8_t MEM_aeskey_2FA_[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
 __extension__ static uint8_t MEM_aeskey_stand_[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
@@ -99,8 +97,6 @@ void memory_erase(void)
     memory_name("Digital Bitbox");
     memory_write_erased(DEFAULT_erased_);
     memory_write_unlocked(DEFAULT_unlocked_);
-    memory_write_touch_timeout(DEFAULT_touch_timeout_);
-    memory_write_touch_thresh(DEFAULT_touch_thresh_);
     memory_access_err_count(DEFAULT_access_err_);
     commander_create_verifypass();
 }
@@ -441,30 +437,6 @@ uint8_t memory_read_erased(void)
 {
     memory_eeprom(NULL, &MEM_erased_, MEM_ERASED_ADDR, 1);
     return MEM_erased_;
-}
-
-
-void memory_write_touch_timeout(const uint16_t t)
-{
-    memory_eeprom((const uint8_t *)&t, (uint8_t *)&MEM_touch_timeout_, MEM_TOUCH_TIMEOUT_ADDR,
-                  2);
-}
-uint16_t memory_read_touch_timeout(void)
-{
-    memory_eeprom(NULL, (uint8_t *)&MEM_touch_timeout_, MEM_TOUCH_TIMEOUT_ADDR, 2);
-    return MEM_touch_timeout_;
-}
-
-
-void memory_write_touch_thresh(const uint16_t t)
-{
-    memory_eeprom((const uint8_t *)&t, (uint8_t *)&MEM_touch_thresh_, MEM_TOUCH_THRESH_ADDR,
-                  2);
-}
-uint16_t memory_read_touch_thresh(void)
-{
-    memory_eeprom(NULL, (uint8_t *)&MEM_touch_thresh_, MEM_TOUCH_THRESH_ADDR, 2);
-    return MEM_touch_thresh_;
 }
 
 

--- a/src/memory.h
+++ b/src/memory.h
@@ -34,10 +34,7 @@
 #define MEM_PAGE_LEN                32
 
 // User Zones: 0x0000 to 0x0FFF
-#define MEM_TOUCH_TIMEOUT_ADDR      0x0022// Zone 0
-#define MEM_TOUCH_THRESH_ADDR       0x0024
-#define MEM_TOUCH_ENABLE_ADDR       0x0026
-#define MEM_ERASED_ADDR             0x0028
+#define MEM_ERASED_ADDR             0x0028// Zone 0
 #define MEM_SETUP_ADDR              0x0030
 #define MEM_ACCESS_ERR_ADDR         0x0032
 #define MEM_UNLOCKED_ADDR           0x0034
@@ -56,8 +53,6 @@
 #define DEFAULT_erased_             0xFF
 #define DEFAULT_setup_              0xFF
 #define DEFAULT_access_err_         STATUS_ACCESS_INITIALIZE
-#define DEFAULT_touch_timeout_      3000// msec
-#define DEFAULT_touch_thresh_       15//v0_4   25//v0_3x
 
 
 typedef enum PASSWORD_ID {
@@ -85,15 +80,11 @@ uint8_t *memory_chaincode(const uint8_t *chain_code);
 uint16_t *memory_mnemonic(const uint16_t *index);
 
 uint8_t *memory_read_memseed(void);
-uint16_t memory_read_touch_timeout(void);
-uint16_t memory_read_touch_thresh(void);
 uint8_t memory_read_erased(void);
 uint8_t memory_read_setup(void);
 uint8_t memory_read_unlocked(void);
 
 void memory_write_memseed(const uint8_t *s);
-void memory_write_touch_timeout(const uint16_t t);
-void memory_write_touch_thresh(const uint16_t t);
 void memory_write_erased(const uint8_t erase);
 void memory_write_setup(const uint8_t setup);
 void memory_write_unlocked(const uint8_t u);

--- a/src/sham.c
+++ b/src/sham.c
@@ -94,14 +94,6 @@ uint8_t touch_button_press(int long_touch)
 }
 
 
-void touch_button_parameters(uint16_t timeout, uint16_t threshold)
-{
-    (void)timeout;
-    (void)threshold;
-    commander_fill_report("touchbutton", FLAG_ERR_NO_MCU, STATUS_SUCCESS);
-}
-
-
 uint8_t flash_read_unique_id(uint32_t *serial, uint32_t len)
 {
     memset(serial, 1, len);

--- a/src/sham.h
+++ b/src/sham.h
@@ -38,7 +38,6 @@ uint8_t sd_write(const char *f, uint16_t f_len, const char *t, uint16_t t_len,
 char *sd_load(const char *f, uint16_t f_len);
 uint8_t sd_list(void);
 uint8_t sd_erase(void);
-void touch_button_parameters(uint16_t timeout, uint16_t threshold);
 uint8_t touch_button_press(int long_touch);
 uint8_t flash_read_unique_id(uint32_t *serial, uint32_t len);
 

--- a/src/touch.h
+++ b/src/touch.h
@@ -30,8 +30,10 @@
 
 #include <stdint.h>
 
+#define QTOUCH_TOUCH_TIMEOUT            3000// msec
+#define QTOUCH_TOUCH_THRESH             15//v0_4   25//v0_3x
 #ifndef TESTING
-#define TOUCH_CHANNEL                   CHANNEL_9
+#define QTOUCH_TOUCH_CHANNEL            CHANNEL_9
 #define QTOUCH_LIB_TYPE_MASK            0x01
 #define QTOUCH_LIB_COMPILER_OFFSET      2
 #define QTOUCH_LIB_COMPILER_MASK        0x01
@@ -45,7 +47,6 @@
 #endif
 
 
-void touch_button_parameters(uint16_t timeout, uint16_t threshold);
 void touch_init(void);
 uint8_t touch_button_press(int long_touch);
 


### PR DESCRIPTION
Touch button parameters are hardcoded, and so memory management is not needed.

In early versions, touch button settings (timeout and threshold) could be changed through the API and were stored in secure EEROM. Later, this was removed from the API for security reasons: setting a low threshold could turn off the touch button and allow remote signing without user knowledge.

