### PR TITLE
add encrypted xpub to allow 2FA of receiving addresses

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -615,6 +615,14 @@ static void commander_process_xpub(yajl_val json_node)
 
     if (xpub[0]) {
         commander_fill_report("xpub", xpub, STATUS_SUCCESS);
+
+        int encrypt_len;
+        char *encoded_report;
+        encoded_report = aes_cbc_b64_encrypt((unsigned char *)xpub,
+                                             strlens(xpub),
+                                             &encrypt_len,
+                                             PASSWORD_VERIFY);
+        commander_fill_report_len("echo", encoded_report, STATUS_SUCCESS, encrypt_len);
     } else {
         commander_fill_report("xpub", FLAG_ERR_BIP32_MISSING, STATUS_ERROR);
     }

--- a/src/flags.h
+++ b/src/flags.h
@@ -74,6 +74,7 @@
         CMD(decrypt)            \
         CMD(encrypt)            \
         CMD(pin)                \
+        CMD(echo)               \
   /* placeholder don't move */  \
         CMD(none)                /* keep last */
 


### PR DESCRIPTION
For an `xpub` command, return the xpub in plaintext as before and additionally return the same xpub encrypted with the verification password. The smartphone app can be used to decode the encrypted xpub in order to verify the receiving address has not been tampered by MITM.

A reply now looks like:
```
{
    "xpub": "xpub6AxQMCbHigHGo8mzY7XMVa7StmKjzoemCHB13uGZrwgb5WsBtCJCyVjSMcMM32m9QvSy4SFYWuxTnLKiZz48AteEEHG6hAMQ996Y1jjvArL" ,
    "echo": "5afwOMNDqeR02X+xDVhfQIViJUOboC+wx/orDEEG7Jmhouui2epYiLGpS76YyZ5F4l08qYRQg0f5Gn00lODdAiCUkbfwwFY3iBC9I+MpsAehx5toiM6vXHbjP6nkupdrjPFwsquguQ0TiHAFMZisgtRGo8znmZZCYeitzMeDULk="
}
```