### PR TITLE
Memory.c: Replace random.h include with stdlib

### DIFF
--- a/src/memory.c
+++ b/src/memory.c
@@ -27,9 +27,9 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include "commander.h"
-#include "random.h"
 #include "memory.h"
 #include "utils.h"
 #include "flags.h"


### PR DESCRIPTION
random.h is not used in memory.c

Also, would it make sense to replace the /dev/urandom in random.c with rand() ?
So the source code would compile on Windows too (or more likely, I didn't try it).
I'm not sure, but I think rand() has worse entropy than /dev/urandom, but it's only used for testing.