### PR TITLE
add device:info command

### DIFF
--- a/src/commander.h
+++ b/src/commander.h
@@ -31,7 +31,6 @@
 
 #include <stdint.h>
 #include "memory.h"
-#include "flags.h"
 #ifndef TESTING
 #include "conf_usb.h"
 
@@ -57,7 +56,7 @@ char *aes_cbc_b64_decrypt(const unsigned char *in, int inlen, int *decrypt_len,
 void commander_clear_report(void);
 void commander_fill_report(const char *attr, const char *val, int err);
 int commander_fill_signature_array(const uint8_t *sig, const uint8_t *pubkey);
-int commander_fill_json_array(const char **key, const char **value, JSON_TYPE *type,
+int commander_fill_json_array(const char **key, const char **value, int *type,
                               int cmd);
 void commander_force_reset(void);
 void commander_create_verifypass(void);

--- a/src/flags.h
+++ b/src/flags.h
@@ -107,6 +107,7 @@
         ATTR(encrypt)           \
         ATTR(password)          \
         ATTR(xpub)              \
+        ATTR(info)              \
         ATTR(__ERASE__)         \
         ATTR(__FORCE__)         \
         ATTR(none)               /* keep last */
@@ -117,13 +118,6 @@ enum ATTR_ENUM { FOREACH_ATTR(GENERATE_ENUM_ATTR) };
 #define CMD_NUM      CMD_none_
 #define ATTR_NUM     ATTR_none_
 
-typedef enum JSON_TYPE {
-    JSON_TYPE_STRING,
-    JSON_TYPE_BOOL,
-    JSON_TYPE_NUMBER,
-    JSON_TYPE_NONE
-} JSON_TYPE;
-
 enum STATUS_FLAGS {
     STATUS_OK, STATUS_ERROR, STATUS_ERROR_MEM,
     STATUS_VERIFY_ECHO, STATUS_VERIFY_SAME, STATUS_VERIFY_DIFFERENT,
@@ -132,7 +126,8 @@ enum STATUS_FLAGS {
     STATUS_RESET,
     STATUS_ACCESS_INITIALIZE, STATUS_ACCESS_ITERATE,
     STATUS_MEM_ERASED, STATUS_MEM_NOT_ERASED,
-    STATUS_SD_REPLACE, STATUS_SD_NO_REPLACE
+    STATUS_SD_REPLACE, STATUS_SD_NO_REPLACE,
+    STATUS_TYPE_STRING, STATUS_TYPE_BOOL, STATUS_TYPE_NUMBER, STATUS_TYPE_NONE
 };
 
 

--- a/src/memory.c
+++ b/src/memory.c
@@ -268,8 +268,8 @@ void memory_mempass(void)
 uint8_t *memory_name(const char *name)
 {
     uint8_t name_b[MEM_PAGE_LEN] = {0};
-    if (strlen(name)) {
-        memcpy(name_b, name, (strlen(name) > MEM_PAGE_LEN) ? MEM_PAGE_LEN : strlen(name));
+    if (strlens(name)) {
+        memcpy(name_b, name, (strlens(name) > MEM_PAGE_LEN) ? MEM_PAGE_LEN : strlens(name));
         memory_eeprom(name_b, MEM_name_, MEM_NAME_ADDR, MEM_PAGE_LEN);
     } else {
         memory_eeprom(NULL, MEM_name_, MEM_NAME_ADDR, MEM_PAGE_LEN);
@@ -323,7 +323,7 @@ int memory_write_aeskey(const char *password, int len, PASSWORD_ID id)
         return STATUS_ERROR;
     }
 
-    if (strlen(password) < PASSWORD_LEN_MIN) {
+    if (strlens(password) < PASSWORD_LEN_MIN) {
         commander_fill_report("password", FLAG_ERR_PASSWORD_LEN, STATUS_ERROR);
         return STATUS_ERROR;
     }

--- a/src/sham.c
+++ b/src/sham.c
@@ -96,6 +96,6 @@ uint8_t touch_button_press(int long_touch)
 
 uint8_t flash_read_unique_id(uint32_t *serial, uint32_t len)
 {
-    memset(serial, 1, len);
+    memset(serial, 1, sizeof(uint32_t) * len);
     return 0; // success
 }

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -607,7 +607,7 @@ int wallet_deserialize_output(char *outputs, const char *keypath, int keypath_le
         }
         const char *key[] = {CMD_STR[CMD_value_], CMD_STR[CMD_script_], 0};
         const char *value[] = {outval, outaddr, 0};
-        JSON_TYPE t[] = {JSON_TYPE_STRING, JSON_TYPE_STRING, JSON_TYPE_NONE};
+        int t[] = {STATUS_TYPE_STRING, STATUS_TYPE_STRING, STATUS_TYPE_NONE};
         commander_fill_json_array(key, value, t, CMD_verify_output_);
     }
     memset(&node, 0, sizeof(HDNode));

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -621,9 +621,22 @@ static void tests_device(void)
     if (api_result_has("error")) {
         goto err;
     }
-    if (!api_result_has("version\":")) {
+    if (!api_result_has("\"version\":")) {
         goto err;
     }
+
+    api_format_send_cmd("device", "info", PASSWORD_STAND);
+    if (api_result_has("error")) {
+        goto err;
+    }
+    if (!api_result_has("\"serial\":") || !api_result_has("\"version\":") ||
+            !api_result_has("\"xpub\":") || !api_result_has("\"name\":")) {
+        goto err;
+    }
+    if (!api_result_has("true") || !api_result_has("\"lock\":")) {
+        goto err;
+    }
+
 
     api_format_send_cmd("reset", "__ERASE__", PASSWORD_STAND);
     if (api_result_has("error")) {
@@ -633,6 +646,22 @@ static void tests_device(void)
     if (api_result_has("error")) {
         goto err;
     }
+
+    api_format_send_cmd("device", "info", PASSWORD_STAND);
+    if (api_result_has("error")) {
+        goto err;
+    }
+    if (!api_result_has("\"serial\":") || !api_result_has("\"version\":") ||
+            !api_result_has("\"xpub\": \"\"") || !api_result_has("\"name\":")) {
+        goto err;
+    }
+    if (!api_result_has("false") || !api_result_has("\"lock\":")) {
+        goto err;
+    }
+
+
+
+
     api_format_send_cmd("reset", "__ERASE__", PASSWORD_NONE);
     if (api_result_has("error")) {
         goto err;

--- a/tests/tests_cmdline.c
+++ b/tests/tests_cmdline.c
@@ -42,7 +42,7 @@ void usage(char *argv[])
 {
     printf("\nExample code to run the Digital Bitbox MCU code.\n");
     printf("  Usage:\n\t%s json_commands\n\n", argv[0]);
-    printf("  Example:\n\t./tests_cmdline \"{ \\\"seed\\\":{\\\"source\\\":\\\"create\\\"} }\"\n\n" );
+    printf("  Example:\n\t./tests_cmdline '{ \"seed\":{\"source\":\"create\"} }'\n\n" );
     printf( "See the online API documentation for a list of JSON commands at\ndigitalbitbox.com.\n\n\n");
 }
 
@@ -54,9 +54,14 @@ int main ( int argc, char *argv[] )
     } else {
         random_init();
         memory_setup();
+
         // A password is required before sending commands.
-        // Refer to the API documentation for more details.
         utils_send_print_cmd("{\"password\":\"standard_password\"}", PASSWORD_NONE);
+
+        // Uncomment to test a command that requires a seed
+        //utils_send_print_cmd("{\"seed\":{\"source\":\"create\"}}", PASSWORD_STAND);
+
+        // Send the command
         utils_send_print_cmd(argv[1], PASSWORD_STAND);
     }
     return 0;


### PR DESCRIPTION
Fixes #55.
Fixes #56.

**New command**
```
{device: info}
```

**Response**
```
{
 "serial": "01010101000000000000000000000000" , 
 "version": "v1.1-7-g5fffa2a" , 
 "xpub":"xpub661MyMwAqRbcFuuEM2tgZEGAVdUSB4A43rmq5GCPh7bZMoA2aGWwsFiEUbT2aN1rUV6RrDbnjSKFxQrss7hQfnTKG3TyeuisYeQaJPQwDto" , 
 "lock": false , 
 "name": "Digital Bitbox" 
}
```

