### PR TITLE
use xpriv instead of mnemonic as backup to micro SD

### DIFF
--- a/src/flags.h
+++ b/src/flags.h
@@ -106,6 +106,8 @@
         ATTR(decrypt)           \
         ATTR(encrypt)           \
         ATTR(password)          \
+        ATTR(mnemonic)          \
+        ATTR(xpriv)             \
         ATTR(xpub)              \
         ATTR(__ERASE__)         \
         ATTR(__FORCE__)         \

--- a/src/flags.h
+++ b/src/flags.h
@@ -106,8 +106,6 @@
         ATTR(decrypt)           \
         ATTR(encrypt)           \
         ATTR(password)          \
-        ATTR(mnemonic)          \
-        ATTR(xpriv)             \
         ATTR(xpub)              \
         ATTR(__ERASE__)         \
         ATTR(__FORCE__)         \

--- a/src/memory.c
+++ b/src/memory.c
@@ -55,7 +55,6 @@ __extension__ static uint8_t MEM_aeskey_memory_[] = {[0 ... MEM_PAGE_LEN - 1] = 
 __extension__ static uint8_t MEM_name_[] = {[0 ... MEM_PAGE_LEN - 1] = '0'};
 __extension__ static uint8_t MEM_master_[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
 __extension__ static uint8_t MEM_master_chain_[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
-__extension__ static uint16_t MEM_mnemonic_[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFFFF};
 
 __extension__ const uint8_t MEM_PAGE_ERASE[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
 __extension__ const uint16_t MEM_PAGE_ERASE_2X[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFFFF};
@@ -82,7 +81,6 @@ void memory_setup(void)
 
 void memory_erase_seed(void)
 {
-    memory_mnemonic(MEM_PAGE_ERASE_2X);
     memory_chaincode(MEM_PAGE_ERASE);
     memory_master(MEM_PAGE_ERASE);
 }
@@ -113,7 +111,6 @@ void memory_clear_variables(void)
     memcpy(MEM_aeskey_verify_, MEM_PAGE_ERASE, MEM_PAGE_LEN);
     memcpy(MEM_master_, MEM_PAGE_ERASE, MEM_PAGE_LEN);
     memcpy(MEM_master_chain_, MEM_PAGE_ERASE, MEM_PAGE_LEN);
-    memcpy(MEM_mnemonic_, MEM_PAGE_ERASE_2X, MEM_PAGE_LEN * 2);
 #endif
 }
 
@@ -292,24 +289,6 @@ uint8_t *memory_chaincode(const uint8_t *chain)
 {
     memory_eeprom_crypt(chain, MEM_master_chain_, MEM_MASTER_BIP32_CHAIN_ADDR);
     return MEM_master_chain_;
-}
-
-
-uint16_t *memory_mnemonic(const uint16_t *idx)
-{
-    if (idx) {
-        memory_eeprom_crypt((const uint8_t *)idx, (uint8_t *)MEM_mnemonic_,
-                            MEM_MNEMONIC_BIP32_ADDR_0);
-        memory_eeprom_crypt((const uint8_t *)idx + MEM_PAGE_LEN,
-                            (uint8_t *)MEM_mnemonic_ + MEM_PAGE_LEN,
-                            MEM_MNEMONIC_BIP32_ADDR_1);
-    } else {
-        memory_eeprom_crypt(NULL, (uint8_t *)MEM_mnemonic_,
-                            MEM_MNEMONIC_BIP32_ADDR_0);
-        memory_eeprom_crypt(NULL, (uint8_t *)MEM_mnemonic_ + MEM_PAGE_LEN,
-                            MEM_MNEMONIC_BIP32_ADDR_1);
-    }
-    return MEM_mnemonic_;
 }
 
 

--- a/src/memory.h
+++ b/src/memory.h
@@ -34,19 +34,16 @@
 #define MEM_PAGE_LEN                32
 
 // User Zones: 0x0000 to 0x0FFF
-#define MEM_ERASED_ADDR             0x0028// Zone 0
-#define MEM_SETUP_ADDR              0x0030
-#define MEM_ACCESS_ERR_ADDR         0x0032
-#define MEM_UNLOCKED_ADDR           0x0034
-#define MEM_AESKEY_MEMSEED_ADDR     0x0036
+#define MEM_ERASED_ADDR             0x0000// Zone 0
+#define MEM_SETUP_ADDR              0x0002
+#define MEM_ACCESS_ERR_ADDR         0x0004
+#define MEM_UNLOCKED_ADDR           0x0006
 #define MEM_NAME_ADDR               0x0100// Zone 1
 #define MEM_MASTER_BIP32_ADDR       0x0200// Zone 2
 #define MEM_MASTER_BIP32_CHAIN_ADDR 0x0300// Zone 3
-#define MEM_MNEMONIC_BIP32_ADDR_0   0x0400// Zone 4
-#define MEM_MNEMONIC_BIP32_ADDR_1   0x0500// Zone 5
-#define MEM_AESKEY_STAND_ADDR       0x0600// Zone 6
-#define MEM_AESKEY_VERIFY_ADDR      0x0700// Zone 7
-#define MEM_AESKEY_CRYPT_ADDR       0x0800// Zone 8
+#define MEM_AESKEY_STAND_ADDR       0x0400// Zone 4
+#define MEM_AESKEY_VERIFY_ADDR      0x0500// Zone 5
+#define MEM_AESKEY_CRYPT_ADDR       0x0600// Zone 6
 
 // Default settings
 #define DEFAULT_unlocked_           0xFF
@@ -77,7 +74,6 @@ uint8_t *memory_read_aeskey(PASSWORD_ID id);
 uint8_t *memory_name(const char *name);
 uint8_t *memory_master(const uint8_t *master_priv_key);
 uint8_t *memory_chaincode(const uint8_t *chain_code);
-uint16_t *memory_mnemonic(const uint16_t *index);
 
 uint8_t *memory_read_memseed(void);
 uint8_t memory_read_erased(void);

--- a/src/version.h
+++ b/src/version.h
@@ -28,6 +28,6 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-const char *DIGITAL_BITBOX_VERSION = "v1.1-6-g8ccaa3b";
+const char *DIGITAL_BITBOX_VERSION = "v1.1-7-g5fffa2a";
 
 #endif

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -50,7 +50,6 @@ extern const uint16_t MEM_PAGE_ERASE_2X[MEM_PAGE_LEN];
 extern const char *CMD_STR[];
 
 static char mnemonic[(BIP39_MAX_WORD_LEN + 1) * MAX_SEED_WORDS + 1];
-static uint16_t seed_index[MAX_SEED_WORDS];
 static uint8_t seed[64];
 static uint8_t rand_data_32[32];
 
@@ -60,7 +59,6 @@ static void clear_static_variables(void)
 {
     memset(seed, 0, sizeof(seed));
     memset(mnemonic, 0, sizeof(mnemonic));
-    memset(seed_index, 0, sizeof(seed_index));
     memset(rand_data_32, 0, sizeof(rand_data_32));
 }
 
@@ -89,53 +87,6 @@ const char *const *wallet_mnemonic_wordlist(void)
 }
 
 
-uint16_t *wallet_index_from_mnemonic(const char *mnemo)
-{
-    int i, j, k, seed_words_n;
-    char *seed_word[MAX_SEED_WORDS] = {NULL};
-    memset(seed_index, 0, sizeof(seed_index));
-    seed_words_n = wallet_split_seed(seed_word, mnemo);
-
-    k = 0;
-    for (i = 0; i < seed_words_n; i++) {
-        if (i >= MAX_SEED_WORDS) {
-            break;
-        }
-        for (j = 0; wordlist[j]; j++) {
-            if (strcmp(seed_word[i], wordlist[j]) == 0) { // word found
-                seed_index[k++] = j + 1; // offset of 1
-                break;
-            }
-        }
-    }
-    return seed_index;
-}
-
-
-char *wallet_mnemonic_from_index(const uint16_t *idx)
-{
-    if (!memcmp(idx, MEM_PAGE_ERASE_2X, 64)) {
-        return NULL;
-    }
-    int i;
-    memset(mnemonic, 0, sizeof(mnemonic));
-    for (i = 0; idx[i]; i++) {
-        if (i >= MAX_SEED_WORDS || idx[i] > BIP39_NUM_WORDS) {
-            return NULL;
-        }
-        strncat(mnemonic, wordlist[idx[i] - 1], BIP39_MAX_WORD_LEN);
-        strncat(mnemonic, " ", 1);
-    }
-
-    if (i == 0 || strlens(mnemonic) < 1) {
-        return NULL;
-    }
-
-    mnemonic[strlens(mnemonic) - 1] = '\0';
-    return mnemonic;
-}
-
-
 int wallet_master_from_xpriv(char *src, int src_len)
 {
     if (src_len != 112 - 1) {
@@ -152,8 +103,7 @@ int wallet_master_from_xpriv(char *src, int src_len)
     }
 
     if (!memcmp(memory_master(node.private_key), MEM_PAGE_ERASE, 32)  ||
-            !memcmp(memory_chaincode(node.chain_code), MEM_PAGE_ERASE, 32) ||
-            !memcmp(memory_mnemonic(wallet_index_from_mnemonic(mnemonic)), MEM_PAGE_ERASE_2X, 64)) {
+            !memcmp(memory_chaincode(node.chain_code), MEM_PAGE_ERASE, 32)) {
         ret = STATUS_ERROR_MEM;
     } else {
         ret = STATUS_OK;
@@ -205,8 +155,7 @@ int wallet_master_from_mnemonic(char *mnemo, int m_len, const char *salt, int s_
     }
 
     if (!memcmp(memory_master(node.private_key), MEM_PAGE_ERASE, 32)  ||
-            !memcmp(memory_chaincode(node.chain_code), MEM_PAGE_ERASE, 32) ||
-            !memcmp(memory_mnemonic(wallet_index_from_mnemonic(mnemonic)), MEM_PAGE_ERASE_2X, 64)) {
+            !memcmp(memory_chaincode(node.chain_code), MEM_PAGE_ERASE, 32)) {
         ret = STATUS_ERROR_MEM;
         goto exit;
     } else {

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -44,10 +44,12 @@ int wallet_split_seed(char **seed_words, const char *message);
 const char *const *wallet_mnemonic_wordlist(void);
 uint16_t *wallet_index_from_mnemonic(const char *mnemo);
 char *wallet_mnemonic_from_index(const uint16_t *index);
+int wallet_master_from_xpriv(char *src, int src_len);
 int wallet_master_from_mnemonic(char *mnemo, int m_len, const char *salt, int s_len);
 int wallet_check_pubkey(const char *pubkeyhash, const char *keypath, int keypath_len);
 int wallet_sign(const char *message, int msg_len, const char *keypath, int keypath_len,
                 int to_hash);
+void wallet_report_xpriv(const char *keypath, int keypath_len, char *xpub);
 void wallet_report_xpub(const char *keypath, int keypath_len, char *xpub);
 int wallet_generate_key(HDNode *node, const char *keypath, int keypath_len,
                         const uint8_t *privkeymaster, const uint8_t *chaincode);

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -42,8 +42,6 @@
 /* BIP32 */
 int wallet_split_seed(char **seed_words, const char *message);
 const char *const *wallet_mnemonic_wordlist(void);
-uint16_t *wallet_index_from_mnemonic(const char *mnemo);
-char *wallet_mnemonic_from_index(const uint16_t *index);
 int wallet_master_from_xpriv(char *src, int src_len);
 int wallet_master_from_mnemonic(char *mnemo, int m_len, const char *salt, int s_len);
 int wallet_check_pubkey(const char *pubkeyhash, const char *keypath, int keypath_len);

--- a/tests/tests_unit.c
+++ b/tests/tests_unit.c
@@ -748,7 +748,6 @@ static void test_mnemonic(void)
         u_assert_str_eq(m, *b);
         wallet_mnemonic_to_seed(m, "TREZOR", seed, 0);
         u_assert_mem_eq(seed, utils_hex_to_uint8(*c), strlen(*c) / 2);
-        u_assert_str_eq(wallet_mnemonic_from_index(wallet_index_from_mnemonic(*b)), *b);
         a += 3;
         b += 3;
         c += 3;


### PR DESCRIPTION
Extended private keys (xpriv) are the most general representation of a BIP32 master seed. On the other hand, a mnemonic seed is specific to a given language (the BIP39 English wordlist is used here, but other wordlists exist), is not recoverable from the xpriv (due to being hashed), and is not fully accepted (e.g. Electrum uses a different mnemonic-to-seed derivation function). 

A mnemonic is an easy way for a user to copy a seed by hand, but copying by hand is not necessary with the DBB. Note that the xpriv uses base58check encoding.

**Changes**
- The `backup` command always save the xpriv to the microSD card. 
- The `seed` command accepts an xpriv source, via either the microSD card or input by USB. (A BIP39 english mnemonic seed can still be input by microSD card or USB, as before.)


**Todo**
- Update API webpage
- Add unit tests for seeding from xpriv 
