### PR TITLE
increase password attempts before auto erase

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -1290,10 +1290,12 @@ static char *commander_decrypt(const char *encrypted_command)
     err_iter = memory_read_access_err_count();  // temporal jitter in code execution.
 
     if (command == NULL) {
+        char msg[256];
         err++;
-        commander_fill_report("input", FLAG_ERR_DECRYPT " "
-                              FLAG_ERR_RESET_WARNING, STATUS_ERROR);
         err_iter = memory_access_err_count(STATUS_ACCESS_ITERATE);
+        snprintf(msg, sizeof(msg), "%s %i %s", FLAG_ERR_DECRYPT,
+                 COMMANDER_MAX_ATTEMPTS - err_iter, FLAG_ERR_RESET_WARNING);
+        commander_fill_report("input", msg, STATUS_ERROR);
     } else {
         yajl_val json_node = yajl_tree_parse(command, NULL, 0);
         if (json_node && YAJL_IS_OBJECT(json_node)) {
@@ -1303,11 +1305,12 @@ static char *commander_decrypt(const char *encrypted_command)
     }
 
     if (!json_object_len && err == 0) {
+        char msg[256];
         err++;
-        commander_fill_report("input", FLAG_ERR_JSON_PARSE " "
-                              FLAG_ERR_RESET_WARNING " "
-                              FLAG_ERR_JSON_BRACKET, STATUS_ERROR);
         err_iter = memory_access_err_count(STATUS_ACCESS_ITERATE);
+        snprintf(msg, sizeof(msg), "%s %s %i %s", FLAG_ERR_JSON_PARSE, FLAG_ERR_JSON_BRACKET,
+                 COMMANDER_MAX_ATTEMPTS - err_iter, FLAG_ERR_RESET_WARNING);
+        commander_fill_report("input", msg, STATUS_ERROR);
     }
 
     if (err_iter - err_count == 0 && err == 0) {

--- a/src/commander.h
+++ b/src/commander.h
@@ -43,7 +43,7 @@
 
 #define COMMANDER_ARRAY_ELEMENT_MAX  1024
 #define VERIFYPASS_FILENAME         "verification.txt"
-#define COMMANDER_MAX_ATTEMPTS      5// max attempts before device reset
+#define COMMANDER_MAX_ATTEMPTS      15// max attempts before device reset
 
 #define AUTOBACKUP_FILENAME         "autobackup_"
 #define AUTOBACKUP_ENCRYPT          "yes"

--- a/src/flags.h
+++ b/src/flags.h
@@ -149,7 +149,7 @@ enum STATUS_FLAGS {
 #define FLAG_ERR_INVALID_CMD        "Invalid command."
 #define FLAG_ERR_MULTIPLE_CMD       "Only one command allowed at a time."
 #define FLAG_ERR_RESET              "Too many failed access attempts. Device reset."
-#define FLAG_ERR_RESET_WARNING      "Too many access errors will cause the device to reset."
+#define FLAG_ERR_RESET_WARNING      "attempts remain before the device is reset."
 #define FLAG_ERR_DEVICE_LOCKED      "Device locked. Erase device to access this command."
 #define FLAG_ERR_BIP32_MISSING      "BIP32 mnemonic not present."
 #define FLAG_ERR_XPUB               "Could not get xpub."


### PR DESCRIPTION
User feedback indicated increasing the number of access attempts before auto-erase is desired such that there is a bit less stress in the case the password cannot be recalled. Was 5, now 15, so brute force is still prevented.