### PR TITLE
switch to bitcoin/secp256k1 ecc library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,10 @@ set(version_file "${CMAKE_CURRENT_SOURCE_DIR}/src/version.h")
 #-----------------------------------------------------------------------------
 # Options for building
 
-option(BUILD_TESTS         "Build the unit tests." ON)
+option(BUILD_TESTS "Build the unit tests." ON)
 option(BUILD_DOCUMENTATION "Build the Doxygen documentation." ON)
-
-set(CMAKE_VERBOSE_MAKEFILE ON)
+option(CMAKE_VERBOSE_MAKEFILE "Verbose build." OFF)
+option(USE_UECC_LIB "Use micro ECC instead bitcoin's secp256k1 library." OFF)
 
 
 #-----------------------------------------------------------------------------
@@ -36,6 +36,12 @@ message(STATUS "Git Commit Hash:        ${GIT_COMMIT_HASH}")
 message(STATUS "CMake version:          ${CMAKE_VERSION}")
 message(STATUS "System:                 ${CMAKE_SYSTEM}")
 message(STATUS "Processor:              ${CMAKE_SYSTEM_PROCESSOR}")
+
+if(USE_UECC_LIB)
+    message(STATUS "ECC library:            micro ECC")
+else()
+    message(STATUS "ECC library:            secp256k1")
+endif()
 
 message(STATUS "Verbose:                ${CMAKE_VERBOSE_MAKEFILE}")
 message(STATUS "Testing:                ${BUILD_TESTS}")
@@ -54,12 +60,17 @@ set(LIBRARY_OUTPUT_PATH  ${CMAKE_CURRENT_BINARY_DIR}/lib)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os")
+#set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -g") # valgrind
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W -Wall -Wextra -Werror -pedantic -Wredundant-decls -Wstrict-prototypes -Wundef -Wshadow -Wpointer-arith -Wmultichar -Wformat-nonliteral -Winit-self -Wformat-security -Wold-style-definition -Wmissing-include-dirs -Wbad-function-cast -Winline -Wnested-externs -Wfloat-equal -Wmissing-declarations -Wswitch-default -Wwrite-strings -Wcast-qual -Wmissing-prototypes")
 
 if(APPLE)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations")
   set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -framework AppKit -framework IOKit")
   set(CMAKE_MACOSX_RPATH ON)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCC)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-function")
 endif()
 
 message(STATUS "C Compiler ID: ${CMAKE_C_COMPILER_ID}")
@@ -157,6 +168,9 @@ if(BUILD_TESTS)
   add_definitions(-DTESTING)
 endif()
 
+if(USE_UECC_LIB)
+    add_definitions(-DECC_USE_UECC_LIB)
+endif()
 
 #-----------------------------------------------------------------------------
 # Build source
@@ -168,5 +182,6 @@ if(BUILD_TESTS)
   add_test(NAME tests_unit COMMAND tests_unit)
   add_test(NAME tests_openssl COMMAND tests_openssl 200)
   add_test(NAME tests_api COMMAND tests_api)
+  add_test(NAME tests_secp256k1 COMMAND tests_secp256k1 4)
   enable_testing()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,8 @@ set(C-SOURCES
     sha2.c
     sham.c
     uECC.c
+    ecc.c
+    secp256k1.c
     utils.c
     wallet.c
 )
@@ -43,6 +45,7 @@ if(WIN32)
 endif()
 
 include_directories(SYSTEM)
+include_directories(secp256k1)
 
 add_library(bitbox
   STATIC

--- a/src/bip32.c
+++ b/src/bip32.c
@@ -29,9 +29,9 @@
 #include "base58.h"
 #include "bip32.h"
 #include "flags.h"
-#include "uECC.h"
 #include "sha2.h"
 #include "hmac.h"
+#include "ecc.h"
 
 
 // write 4 big endian bytes
@@ -64,7 +64,7 @@ int hdnode_from_seed(const uint8_t *seed, int seed_len, HDNode *out)
     hmac_sha512((const uint8_t *)"Bitcoin seed", 12, seed, seed_len, I);
     memcpy(out->private_key, I, 32);
 
-    if (!uECC_isValid(out->private_key)) {
+    if (!ecc_isValid(out->private_key)) {
         memset(I, 0, sizeof(I));
         return DBB_ERROR;
     }
@@ -104,16 +104,13 @@ int hdnode_private_ckd(HDNode *inout, uint32_t i)
 
     memcpy(z, inout->private_key, 32);
 
-    if (!uECC_isValid(z)) {
+    if (!ecc_isValid(z)) {
         memset(data, 0, sizeof(data));
         memset(I, 0, sizeof(I));
         return DBB_ERROR;
     }
 
-
-    uECC_generate_private_key(inout->private_key, p, z);
-
-    if (!uECC_isValid(inout->private_key)) {
+    if (!ecc_generate_private_key(inout->private_key, p, z)) {
         memset(data, 0, sizeof(data));
         memset(I, 0, sizeof(I));
         return DBB_ERROR;
@@ -122,7 +119,7 @@ int hdnode_private_ckd(HDNode *inout, uint32_t i)
     inout->depth++;
     inout->child_num = i;
 
-    hdnode_fill_public_key(inout); // very slow
+    hdnode_fill_public_key(inout);
 
     memset(data, 0, sizeof(data));
     memset(I, 0, sizeof(I));
@@ -132,7 +129,7 @@ int hdnode_private_ckd(HDNode *inout, uint32_t i)
 
 void hdnode_fill_public_key(HDNode *node)
 {
-    uECC_get_public_key33(node->private_key, node->public_key);
+    ecc_get_public_key33(node->private_key, node->public_key);
 }
 
 

--- a/src/ecc.c
+++ b/src/ecc.c
@@ -1,0 +1,289 @@
+/*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2015 Douglas J. Bakkum
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "sha2.h"
+#include "flags.h"
+#include "utils.h"
+#include "ecc.h"
+#ifndef ECC_USE_UECC_LIB
+#include "secp256k1/include/secp256k1.h"
+
+
+static secp256k1_context_t *ctx = NULL;
+
+
+void ecc_context_init(void)
+{
+#ifdef TESTING
+    ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+#else
+    ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
+#endif
+}
+
+
+void ecc_context_destroy(void)
+{
+    secp256k1_context_destroy(ctx);
+}
+
+
+int ecc_sign_digest(const uint8_t *private_key, const uint8_t *data, uint8_t *sig)
+{
+    secp256k1_ecdsa_signature_t signature;
+
+    if (!ctx) {
+        ecc_context_init();
+    }
+
+    if (secp256k1_ecdsa_sign(ctx, &signature, (const unsigned char *)data,
+                             (const unsigned char *)private_key, secp256k1_nonce_function_rfc6979, NULL)) {
+        int i;
+        for (i = 0; i < 32; i++) {
+            sig[i] = signature.data[32 - i - 1];
+            sig[i + 32] = signature.data[64 - i - 1];
+        }
+        return 0;
+    } else {
+        return 1;
+    }
+}
+
+
+int ecc_sign(const uint8_t *private_key, const uint8_t *msg, uint32_t msg_len,
+             uint8_t *sig)
+{
+    uint8_t hash[SHA256_DIGEST_LENGTH];
+    sha256_Raw(msg, msg_len, hash);
+    return ecc_sign_digest(private_key, hash, sig);
+}
+
+
+int ecc_sign_double(const uint8_t *privateKey, const uint8_t *msg, uint32_t msg_len,
+                    uint8_t *sig)
+{
+    uint8_t hash[SHA256_DIGEST_LENGTH];
+    sha256_Raw(msg, msg_len, hash);
+    sha256_Raw(hash, SHA256_DIGEST_LENGTH, hash);
+    return ecc_sign_digest(privateKey, hash, sig);
+}
+
+
+static int ecc_verify_digest(const uint8_t *public_key, const uint8_t *hash,
+                             const uint8_t *sig)
+{
+
+    int public_key_len;
+    secp256k1_ecdsa_signature_t signature;
+    secp256k1_pubkey_t pubkey;
+
+    if (!ctx) {
+        ecc_context_init();
+    }
+
+    int i;
+    for (i = 0; i < 32; i++) {
+        signature.data[32 - i - 1] = sig[i];
+        signature.data[64 - i - 1] = sig[i + 32];
+    }
+
+    if (public_key[0] == 0x04) {
+        public_key_len = 65;
+    } else if (public_key[0] == 0x02 || public_key[0] == 0x03) {
+        public_key_len = 33;
+    } else {
+        return 1;
+    }
+
+    if (!secp256k1_ec_pubkey_parse(ctx, &pubkey, public_key, public_key_len)) {
+        return 1;
+    }
+
+    if (!secp256k1_ecdsa_verify(ctx, &signature, (const unsigned char *)hash, &pubkey)) {
+        return 1;
+    }
+
+    return 0; // success
+}
+
+
+int ecc_verify(const uint8_t *public_key, const uint8_t *signature, const uint8_t *msg,
+               uint32_t msg_len)
+{
+    uint8_t hash[SHA256_DIGEST_LENGTH];
+    sha256_Raw(msg, msg_len, hash);
+    return ecc_verify_digest(public_key, hash, signature);
+}
+
+
+int ecc_verify_double(const uint8_t *public_key, const uint8_t *signature,
+                      const uint8_t *msg, uint32_t msg_len)
+{
+    uint8_t hash[SHA256_DIGEST_LENGTH];
+    sha256_Raw(msg, msg_len, hash);
+    sha256_Raw(hash, SHA256_DIGEST_LENGTH, hash);
+    return ecc_verify_digest(public_key, hash, signature);
+}
+
+
+int ecc_generate_private_key(uint8_t *private_child, const uint8_t *private_master,
+                             const uint8_t *z)
+{
+    memcpy(private_child, private_master, 32);
+    return secp256k1_ec_privkey_tweak_add(ctx, (unsigned char *)private_child,
+                                          (const unsigned char *)z);
+}
+
+
+int ecc_isValid(uint8_t *private_key)
+{
+    if (!ctx) {
+        ecc_context_init();
+    }
+    return (secp256k1_ec_seckey_verify(ctx, (const unsigned char *)private_key));
+}
+
+
+static void ecc_get_pubkey(const uint8_t *private_key, uint8_t *public_key,
+                           int public_key_len, int compressed)
+{
+    secp256k1_pubkey_t pubkey;
+
+    memset(public_key, 0, public_key_len);
+
+    if (!ctx) {
+        ecc_context_init();
+    }
+
+    if (!secp256k1_ec_pubkey_create(ctx, &pubkey, (const unsigned char *)private_key)) {
+        return;
+    }
+
+    if (!secp256k1_ec_pubkey_serialize(ctx, public_key, &public_key_len, &pubkey,
+                                       compressed)) {
+        return;
+    }
+
+    return;
+}
+
+
+void ecc_get_public_key65(const uint8_t *private_key, uint8_t *public_key)
+{
+    ecc_get_pubkey(private_key, public_key, 65, 0);
+}
+
+
+void ecc_get_public_key33(const uint8_t *private_key, uint8_t *public_key)
+{
+    ecc_get_pubkey(private_key, public_key, 33, 1);
+}
+
+
+#else
+
+
+#include "uECC.h"
+
+
+void ecc_context_init(void)
+{
+    // pass
+}
+
+
+void ecc_context_destroy(void)
+{
+    // pass
+}
+
+
+int ecc_sign_digest(const uint8_t *private_key, const uint8_t *data, uint8_t *sig)
+{
+    return uECC_sign_digest(private_key, data, sig);
+}
+
+
+int ecc_sign(const uint8_t *private_key, const uint8_t *msg, uint32_t msg_len,
+             uint8_t *sig)
+{
+    return uECC_sign(private_key, msg, msg_len, sig);
+}
+
+
+int ecc_sign_double(const uint8_t *privateKey, const uint8_t *msg, uint32_t msg_len,
+                    uint8_t *sig)
+{
+    return uECC_sign_double(privateKey, msg, msg_len, sig);
+}
+
+
+int ecc_verify(const uint8_t *public_key, const uint8_t *signature, const uint8_t *msg,
+               uint32_t msg_len)
+{
+    return uECC_verify(public_key, signature, msg, msg_len);
+}
+
+
+int ecc_verify_double(const uint8_t *public_key, const uint8_t *signature,
+                      const uint8_t *msg, uint32_t msg_len)
+{
+    return uECC_verify_double(public_key, signature, msg, msg_len);
+}
+
+
+int ecc_generate_private_key(uint8_t *private_child, const uint8_t *private_master,
+                             const uint8_t *z)
+{
+    uECC_generate_private_key(private_child, private_master, z);
+    return uECC_isValid(private_child);
+}
+
+
+int ecc_isValid(uint8_t *private_key)
+{
+    return uECC_isValid(private_key);
+}
+
+
+void ecc_get_public_key65(const uint8_t *private_key, uint8_t *public_key)
+{
+    uECC_get_public_key65(private_key, public_key);
+}
+
+
+void ecc_get_public_key33(const uint8_t *private_key, uint8_t *public_key)
+{
+    uECC_get_public_key33(private_key, public_key);
+}
+
+
+#endif

--- a/src/ecc.h
+++ b/src/ecc.h
@@ -25,43 +25,29 @@
 */
 
 
-#include <stdio.h>
-#include <string.h>
-
-#include "ecc.h"
-#include "utils.h"
-#include "random.h"
-#include "memory.h"
-#include "commander.h"
+#ifndef _ECC_H_
+#define _ECC_H_
 
 
-static void usage(char *argv[])
-{
-    printf("\nExample code to run the Digital Bitbox MCU code.\n");
-    printf("  Usage:\n\t%s json_commands\n\n", argv[0]);
-    printf("  Example:\n\t./tests_cmdline '{ \"seed\":{\"source\":\"create\"} }'\n\n" );
-    printf( "See the online API documentation for a list of JSON commands at\ndigitalbitbox.com.\n\n\n");
-}
+#include <stdint.h>
 
 
-int main ( int argc, char *argv[] )
-{
-    if (argc != 2) {
-        usage(argv);
-    } else {
-        random_init();
-        memory_setup();
-        ecc_context_init();
+void ecc_context_init(void);
+void ecc_context_destroy(void);
+int ecc_sign_digest(const uint8_t *private_key, const uint8_t *data, uint8_t *sig);
+int ecc_sign(const uint8_t *private_key, const uint8_t *msg, uint32_t msg_len,
+             uint8_t *sig);
+int ecc_sign_double(const uint8_t *privateKey, const uint8_t *msg, uint32_t msg_len,
+                    uint8_t *sig);
+int ecc_verify_double(const uint8_t *public_key, const uint8_t *signature,
+                      const uint8_t *msg, uint32_t msg_len);
+int ecc_verify(const uint8_t *public_key, const uint8_t *signature, const uint8_t *msg,
+               uint32_t msg_len);
+int ecc_generate_private_key(uint8_t *private_child, const uint8_t *private_master,
+                             const uint8_t *z);
+int ecc_isValid(uint8_t *private_key);
+void ecc_get_public_key65(const uint8_t *private_key, uint8_t *public_key);
+void ecc_get_public_key33(const uint8_t *private_key, uint8_t *public_key);
 
-        // A password is required before sending commands.
-        utils_send_print_cmd("{\"password\":\"standard_password\"}", PASSWORD_NONE);
 
-        // Uncomment to test a command that requires a seed
-        //utils_send_print_cmd("{\"seed\":{\"source\":\"create\"}}", PASSWORD_STAND);
-
-        // Send the command
-        utils_send_print_cmd(argv[1], PASSWORD_STAND);
-        ecc_context_destroy();
-    }
-    return 0;
-}
+#endif

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -25,43 +25,29 @@
 */
 
 
-#include <stdio.h>
-#include <string.h>
-
-#include "ecc.h"
-#include "utils.h"
-#include "random.h"
-#include "memory.h"
-#include "commander.h"
+// Provides secp256k1 access in libbitbox.a, as required by the test
+// functions. Then, the secp256k1/ submodule code is left 'as is'.
 
 
-static void usage(char *argv[])
-{
-    printf("\nExample code to run the Digital Bitbox MCU code.\n");
-    printf("  Usage:\n\t%s json_commands\n\n", argv[0]);
-    printf("  Example:\n\t./tests_cmdline '{ \"seed\":{\"source\":\"create\"} }'\n\n" );
-    printf( "See the online API documentation for a list of JSON commands at\ndigitalbitbox.com.\n\n\n");
-}
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winline"
+#endif
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
+#endif
 
 
-int main ( int argc, char *argv[] )
-{
-    if (argc != 2) {
-        usage(argv);
-    } else {
-        random_init();
-        memory_setup();
-        ecc_context_init();
+#define USE_ECMULT_STATIC_PRECOMPUTATION 1
+#define USE_BASIC_CONFIG 1
 
-        // A password is required before sending commands.
-        utils_send_print_cmd("{\"password\":\"standard_password\"}", PASSWORD_NONE);
+#include "secp256k1/src/basic-config.h"
+#include "secp256k1/src/secp256k1.c"
 
-        // Uncomment to test a command that requires a seed
-        //utils_send_print_cmd("{\"seed\":{\"source\":\"create\"}}", PASSWORD_STAND);
-
-        // Send the command
-        utils_send_print_cmd(argv[1], PASSWORD_STAND);
-        ecc_context_destroy();
-    }
-    return 0;
-}
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif

--- a/src/uECC.c
+++ b/src/uECC.c
@@ -894,7 +894,7 @@ int uECC_sign_double(const uint8_t *p_privateKey, const uint8_t *msg, uint32_t m
     return uECC_sign_digest(p_privateKey, p_hash, p_signature);
 }
 
-/* Verify an ECDSA signature.
+/* ECDSA signature.
    Returns 0 always. */
 int uECC_sign_digest(const uint8_t p_privateKey[uECC_BYTES],
                      const uint8_t p_hash[uECC_BYTES], uint8_t p_signature[uECC_BYTES * 2])
@@ -909,7 +909,7 @@ int uECC_sign_digest(const uint8_t p_privateKey[uECC_BYTES],
     do {
     repeat:
         // Deterministic K
-        generate_k_rfc6979_test(k_b, p_privateKey, p_hash);
+        uECC_generate_k_rfc6979_test(k_b, p_privateKey, p_hash);
         vli_bytesToNative(k, k_b);
 
         if (vli_isZero(k)) {
@@ -1152,7 +1152,8 @@ void uECC_get_public_key64(const uint8_t p_privateKey[uECC_BYTES],
 
 /* generate K in a deterministic way, according to RFC6979
    http://tools.ietf.org/html/rfc6979 */
-int generate_k_rfc6979_test(uint8_t *secret, const uint8_t *priv_key, const uint8_t *hash)
+int uECC_generate_k_rfc6979_test(uint8_t *secret, const uint8_t *priv_key,
+                                 const uint8_t *hash)
 {
     int i;
     uint8_t v[32], k[32], bx[2 * 32], buf[32 + 1 + sizeof(bx)], z1[32];

--- a/src/uECC.h
+++ b/src/uECC.h
@@ -80,8 +80,8 @@ void uECC_generate_private_key(uint8_t *p_privateChild,
 int uECC_isValid(uint8_t *p_key);
 
 // Deterministic signatures following RFC6979
-int generate_k_rfc6979_test(uint8_t *secret, const uint8_t *priv_key,
-                            const uint8_t *hash);
+int uECC_generate_k_rfc6979_test(uint8_t *secret, const uint8_t *priv_key,
+                                 const uint8_t *hash);
 
 // Get the public key from the private key
 void uECC_get_public_key65(const uint8_t p_privateKey[uECC_BYTES],

--- a/src/version.h
+++ b/src/version.h
@@ -28,6 +28,6 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-const char *DIGITAL_BITBOX_VERSION = "v1.1-18-g7ab5fad";
+const char *DIGITAL_BITBOX_VERSION = "v1.1-20-g60032f3";
 
 #endif

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -41,9 +41,9 @@
 #include "utils.h"
 #include "flags.h"
 #include "sha2.h"
-#include "uECC.h"
-
+#include "ecc.h"
 #include "bip39_english.h"
+
 
 extern const uint8_t MEM_PAGE_ERASE[MEM_PAGE_LEN];
 extern const uint16_t MEM_PAGE_ERASE_2X[MEM_PAGE_LEN];
@@ -301,7 +301,7 @@ int wallet_check_pubkey(const char *address, const char *keypath, int keypath_le
         goto err;
     }
 
-    uECC_get_public_key33(node.private_key, pub_key);
+    ecc_get_public_key33(node.private_key, pub_key);
     wallet_get_address(pub_key, 0, addr, sizeof(addr));
 
     memset(&node, 0, sizeof(HDNode));
@@ -351,10 +351,10 @@ int wallet_sign(const char *message, int msg_len, const char *keypath, int keypa
 
     int ret = 0;
     if (to_hash) {
-        ret = uECC_sign_double(node.private_key, utils_hex_to_uint8(message), msg_len / 2, sig);
+        ret = ecc_sign_double(node.private_key, utils_hex_to_uint8(message), msg_len / 2, sig);
     } else {
         memcpy(data, utils_hex_to_uint8(message), 32);
-        ret = uECC_sign_digest(node.private_key, data, sig);
+        ret = ecc_sign_digest(node.private_key, data, sig);
     }
 
     if (ret) {
@@ -363,7 +363,7 @@ int wallet_sign(const char *message, int msg_len, const char *keypath, int keypa
         goto err;
     }
 
-    uECC_get_public_key33(node.private_key, pub_key);
+    ecc_get_public_key33(node.private_key, pub_key);
     memset(&node, 0, sizeof(HDNode));
     clear_static_variables();
     return commander_fill_signature_array(sig, pub_key);
@@ -597,7 +597,7 @@ int wallet_deserialize_output(char *outputs, const char *keypath, int keypath_le
                 memset(&node, 0, sizeof(HDNode));
                 return DBB_ERROR;
             }
-            uECC_get_public_key33(node.private_key, pub_key33);
+            ecc_get_public_key33(node.private_key, pub_key33);
             wallet_get_pubkeyhash(pub_key33, pubkeyhash);
             wallet_get_address(pub_key33, 0, address, 36);
             if (strstr(outaddr, utils_uint8_to_hex(pubkeyhash, 20))) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,6 @@
 include_directories(../src)
+include_directories(../src/secp256k1)
+
 
 #-----------------------------------------------------------------------------
 # Build tests_unit
@@ -17,6 +19,12 @@ target_link_libraries(tests_openssl bitbox ${OPENSSL_LIBRARIES})
 # Build tests_cmdline
 add_executable(tests_cmdline tests_cmdline.c)
 target_link_libraries(tests_cmdline bitbox)
+
+
+#-----------------------------------------------------------------------------
+# Build tests for secp256k1
+add_executable(tests_secp256k1 tests_secp256k1.c)
+target_link_libraries(tests_secp256k1 bitbox)
 
 
 #-----------------------------------------------------------------------------

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -29,6 +29,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+
+#include "ecc.h"
 #include "utils.h"
 #include "flags.h"
 #include "random.h"
@@ -953,6 +955,23 @@ err:
 }
 
 
+#ifdef ECC_USE_UECC_LIB
+const char hash_1_input[] =
+    "41fa23804d6fe53c296a5ac93a2e21719f9c6f20b2645d04d047150087cd812acedefc98a7d87f1379efb84dc684ab947dc4e583d2c3e1d50f372012b3d8c95e";
+const char hash_2_input_1[] =
+    "d4464e76d679b062ec867c7ebb961fc27cab810ccd6198bd993acef5a84273bcf16b256cfd77768df1bbce20333904c5e93873cee26ac446afdd62a5394b73ad";
+const char hash_2_input_2[] =
+    "031145194147dada762c77ff85fd5cb493f56596de20f235c35507cd72716134e49cbe288c46f90da19bd1552c406e64425169520d433113a78b480ca3c5d340";
+#else
+const char hash_1_input[] =
+    "41fa23804d6fe53c296a5ac93a2e21719f9c6f20b2645d04d047150087cd812a31210367582780ec861047b2397b546a3ce9f762dc84be66b09b3e7a1c5d77e3";
+const char hash_2_input_1[] =
+    "d4464e76d679b062ec867c7ebb961fc27cab810ccd6198bd993acef5a84273bc0e94da93028889720e4431dfccc6fb38d1766917ccdddbf50ff4fbe796eacd94";
+const char hash_2_input_2[] =
+    "031145194147dada762c77ff85fd5cb493f56596de20f235c35507cd727161341b6341d773b906f25e642eaad3bf919a785d7394a2056f28184716802c706e01";
+#endif
+
+
 static void tests_sign_meta(void)
 {
     api_reset_cmd_count();
@@ -1053,7 +1072,7 @@ static void tests_sign_meta(void)
     if (!api_result_has(CMD_STR[CMD_pubkey_])) {
         goto err;
     }
-    if (!api_result_has("41fa23804d6fe53c296a5ac93a2e21719f9c6f20b2645d04d047150087cd812acedefc98a7d87f1379efb84dc684ab947dc4e583d2c3e1d50f372012b3d8c95e")) {
+    if (!api_result_has(hash_1_input)) {
         goto err;
     }
     if (!api_result_has(CMD_STR[CMD_pubkey_])) {
@@ -1072,7 +1091,6 @@ static void tests_sign_meta(void)
       raw_tx = 01000000029ecf1f09baed314ee1cc37ee2236dca5f71f7dddc83a2a1b6358e739ac68c43f0000000000ffffffff9ecf1f09baed314ee1cc37ee2236dca5f71f7dddc83a2a1b6358e739ac68c43f010000001976a914fd342347278e14013d17d53ed3c4aa7bf27eceb788acffffffff01c8000000000000001976a914584495bb22f4cb66cd47f2255cbc7178c6f3caeb88ac0000000001000000
       sha256(sha256(hex2byte(raw_tx))) = c12d791451bb41fd4b5145bcef25f794ca33c0cf4fe9d24f956086c5aa858a9d
     */
-
     api_format_send_cmd("sign",
                         "{\"type\":\"meta\", \"meta\":\"_meta_data_\", \"data\":[{\"hash\":\"c12d791451bb41fd4b5145bcef25f794ca33c0cf4fe9d24f956086c5aa858a9d\", \"keypath\":\"m/44'/0'/0'/1/8\"},{\"hash\":\"3dfc3b1ed349e9b361b31c706fbf055ebf46ae725740f6739e2dfa87d2a98790\", \"keypath\":\"m/44'/0'/0'/0/5\"}]}",
                         PASSWORD_STAND);
@@ -1096,10 +1114,10 @@ static void tests_sign_meta(void)
     if (!api_result_has("sign")) {
         goto err;
     }
-    if (!api_result_has("d4464e76d679b062ec867c7ebb961fc27cab810ccd6198bd993acef5a84273bcf16b256cfd77768df1bbce20333904c5e93873cee26ac446afdd62a5394b73ad")) {
+    if (!api_result_has(hash_2_input_1)) {
         goto err;
     }
-    if (!api_result_has("031145194147dada762c77ff85fd5cb493f56596de20f235c35507cd72716134e49cbe288c46f90da19bd1552c406e64425169520d433113a78b480ca3c5d340")) {
+    if (!api_result_has(hash_2_input_2)) {
         goto err;
     }
     if (!api_result_has(CMD_STR[CMD_pubkey_])) {
@@ -1153,7 +1171,7 @@ static void tests_sign_meta(void)
         if (!api_result_has("sign")) {
             goto err;
         }
-        if (!api_result_has("41fa23804d6fe53c296a5ac93a2e21719f9c6f20b2645d04d047150087cd812acedefc98a7d87f1379efb84dc684ab947dc4e583d2c3e1d50f372012b3d8c95e")) {
+        if (!api_result_has(hash_1_input)) {
             goto err;
         }
         if (!api_result_has(CMD_STR[CMD_pubkey_])) {
@@ -1194,10 +1212,10 @@ static void tests_sign_meta(void)
         if (!api_result_has("sign")) {
             goto err;
         }
-        if (!api_result_has("d4464e76d679b062ec867c7ebb961fc27cab810ccd6198bd993acef5a84273bcf16b256cfd77768df1bbce20333904c5e93873cee26ac446afdd62a5394b73ad")) {
+        if (!api_result_has(hash_2_input_1)) {
             goto err;
         }
-        if (!api_result_has("031145194147dada762c77ff85fd5cb493f56596de20f235c35507cd72716134e49cbe288c46f90da19bd1552c406e64425169520d433113a78b480ca3c5d340")) {
+        if (!api_result_has(hash_2_input_2)) {
             goto err;
         }
         if (!api_result_has(CMD_STR[CMD_pubkey_])) {
@@ -1304,26 +1322,27 @@ static void tests_sign(void)
         if (!api_result_has("verify_output")) {
             goto err;
         }
-        if (!api_result_has("value"))         {
+        if (!api_result_has("value")) {
             goto err;
         }
-        if (!api_result_has("2200"))          {
+        if (!api_result_has("2200")) {
             goto err;
         }
-        if (!api_result_has("script"))        {
+        if (!api_result_has("script")) {
             goto err;
         }
         if (!api_result_has("76a91452922e52d08a2c1f1e4120803e56363fd7a8195188ac")) {
             goto err;
         }
     }
+
     api_format_send_cmd("sign",
                         "{\"type\":\"transaction\", \"data\":\"0100000001e4b8a097d6d5cd351f69d9099e277b8a1c39a219991a4e5f9f86805faf649899010000001976a91488e6399fab42b2ea637da283dd87e70f4862e10c88acffffffff0298080000000000001976a91452922e52d08a2c1f1e4120803e56363fd7a8195188acb83d0000000000001976a914fd342347278e14013d17d53ed3c4aa7bf27eceb788ac0000000001000000\", \"keypath\":\"m/44'/0'/0'/1/7\", \"changekeypath\":\"m/44'/0'/0'/1/8\"}",
                         PASSWORD_STAND);
     if (!api_result_has("sign")) {
         goto err;
     }
-    if (!api_result_has("41fa23804d6fe53c296a5ac93a2e21719f9c6f20b2645d04d047150087cd812acedefc98a7d87f1379efb84dc684ab947dc4e583d2c3e1d50f372012b3d8c95e")) {
+    if (!api_result_has(hash_1_input)) {
         goto err;
     }
     if (!api_result_has("pubkey")) {
@@ -1344,13 +1363,13 @@ static void tests_sign(void)
         if (!api_result_has("verify_output")) {
             goto err;
         }
-        if (!api_result_has("value"))         {
+        if (!api_result_has("value")) {
             goto err;
         }
-        if (!api_result_has("200"))           {
+        if (!api_result_has("200")) {
             goto err;
         }
-        if (!api_result_has("script"))        {
+        if (!api_result_has("script")) {
             goto err;
         }
         if (!api_result_has("76a914584495bb22f4cb66cd47f2255cbc7178c6f3caeb88ac")) {
@@ -1363,7 +1382,7 @@ static void tests_sign(void)
     if (!api_result_has("sign")) {
         goto err;
     }
-    if (!api_result_has("031145194147dada762c77ff85fd5cb493f56596de20f235c35507cd72716134e49cbe288c46f90da19bd1552c406e64425169520d433113a78b480ca3c5d340")) {
+    if (!api_result_has(hash_2_input_2)) {
         goto err;
     }
     if (!api_result_has("pubkey")) {
@@ -1378,7 +1397,7 @@ static void tests_sign(void)
     if (!api_result_has("sign")) {
         goto err;
     }
-    if (!api_result_has("d4464e76d679b062ec867c7ebb961fc27cab810ccd6198bd993acef5a84273bcf16b256cfd77768df1bbce20333904c5e93873cee26ac446afdd62a5394b73ad")) {
+    if (!api_result_has(hash_2_input_1)) {
         goto err;
     }
     if (!api_result_has("pubkey")) {
@@ -1408,13 +1427,13 @@ static void tests_sign(void)
         if (!api_result_has("verify_output")) {
             goto err;
         }
-        if (!api_result_has("value"))         {
+        if (!api_result_has("value")) {
             goto err;
         }
-        if (!api_result_has("2200"))          {
+        if (!api_result_has("2200")) {
             goto err;
         }
-        if (!api_result_has("script"))        {
+        if (!api_result_has("script")) {
             goto err;
         }
         if (!api_result_has("76a91452922e52d08a2c1f1e4120803e56363fd7a8195188ac")) {
@@ -1431,7 +1450,7 @@ static void tests_sign(void)
         if (!api_result_has("sign")) {
             goto err;
         }
-        if (!api_result_has("41fa23804d6fe53c296a5ac93a2e21719f9c6f20b2645d04d047150087cd812acedefc98a7d87f1379efb84dc684ab947dc4e583d2c3e1d50f372012b3d8c95e")) {
+        if (!api_result_has(hash_1_input)) {
             goto err;
         }
         if (!api_result_has("pubkey")) {
@@ -1454,13 +1473,13 @@ static void tests_sign(void)
         if (!api_result_has("verify_output")) {
             goto err;
         }
-        if (!api_result_has("value"))         {
+        if (!api_result_has("value")) {
             goto err;
         }
-        if (!api_result_has("200"))           {
+        if (!api_result_has("200")) {
             goto err;
         }
-        if (!api_result_has("script"))        {
+        if (!api_result_has("script")) {
             goto err;
         }
         if (!api_result_has("76a914584495bb22f4cb66cd47f2255cbc7178c6f3caeb88ac")) {
@@ -1477,7 +1496,7 @@ static void tests_sign(void)
         if (!api_result_has("sign")) {
             goto err;
         }
-        if (!api_result_has("031145194147dada762c77ff85fd5cb493f56596de20f235c35507cd72716134e49cbe288c46f90da19bd1552c406e64425169520d433113a78b480ca3c5d340")) {
+        if (!api_result_has(hash_2_input_2)) {
             goto err;
         }
         if (!api_result_has("pubkey")) {
@@ -1497,7 +1516,7 @@ static void tests_sign(void)
         if (!api_result_has("sign")) {
             goto err;
         }
-        if (!api_result_has("d4464e76d679b062ec867c7ebb961fc27cab810ccd6198bd993acef5a84273bcf16b256cfd77768df1bbce20333904c5e93873cee26ac446afdd62a5394b73ad")) {
+        if (!api_result_has(hash_2_input_1)) {
             goto err;
         }
         if (!api_result_has("pubkey")) {
@@ -1682,6 +1701,7 @@ int main(void)
     // Test the C code API
     TEST_LIVE_DEVICE = 0;
     random_init();
+    ecc_context_init();
     memory_setup();
     printf("\n\nInternal API Result:\n");
     tests_run();
@@ -1702,5 +1722,6 @@ int main(void)
 #endif
 
 
+    ecc_context_destroy();
     return TESTS_FAIL;
 }

--- a/tests/tests_openssl.c
+++ b/tests/tests_openssl.c
@@ -22,13 +22,14 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+
 #include <openssl/ecdsa.h>
 #include <openssl/obj_mac.h>
 #include <openssl/sha.h>
 #include <stdio.h>
 #include <stdint.h>
 
-#include "uECC.h"
+#include "ecc.h"
 #include "random.h"
 #include "utils.h"
 
@@ -43,6 +44,7 @@ int main(int argc, char *argv[])
     int cnt = 0, err = 0;
 
     random_init();
+    ecc_context_init();
     ecgroup = EC_GROUP_new_by_curve_name(NID_secp256k1);
 
     unsigned long max_iterations = -1;
@@ -87,24 +89,24 @@ int main(int argc, char *argv[])
             }
         }
 
-        // use our ECDSA signer to sign the message with the key
-        if (uECC_sign(priv_key, msg, msg_len, sig)) {
+        if (ecc_sign(priv_key, msg, msg_len, sig)) {
             printf("signing failed\n");
             err++;
             break;
         }
 
         // generate public key from private key
-        uECC_get_public_key33(priv_key, pub_key33);
-        uECC_get_public_key65(priv_key, pub_key65);
+        ecc_get_public_key33(priv_key, pub_key33);
+        ecc_get_public_key65(priv_key, pub_key65);
+
 
         // verify the message signature
-        if (uECC_verify(pub_key65, sig, msg, msg_len)) {
+        if (ecc_verify(pub_key65, sig, msg, msg_len)) {
             printf("verification failed (pub_key_len = 65)\n");
             err++;
             break;
         }
-        if (uECC_verify(pub_key33, sig, msg, msg_len)) {
+        if (ecc_verify(pub_key33, sig, msg, msg_len)) {
             printf("verification failed (pub_key_len = 33)\n");
             err++;
             break;
@@ -138,9 +140,9 @@ int main(int argc, char *argv[])
     if (err) {
         printf("message to sign:\n%s\n\n", utils_uint8_to_hex(msg, msg_len));
         printf("eckey dump:\n%.*s\n\n", p_len, utils_uint8_to_hex(p, sizeof(buffer)));
-        //printf("eckey dump:\n%s\n\n", utils_uint8_to_hex(p, sizeof(buffer)));
     }
 
     EC_GROUP_free(ecgroup);
+    ecc_context_destroy();
     return err;
 }

--- a/tests/tests_secp256k1.c
+++ b/tests/tests_secp256k1.c
@@ -25,43 +25,30 @@
 */
 
 
-#include <stdio.h>
-#include <string.h>
-
-#include "ecc.h"
-#include "utils.h"
-#include "random.h"
-#include "memory.h"
-#include "commander.h"
-
-
-static void usage(char *argv[])
-{
-    printf("\nExample code to run the Digital Bitbox MCU code.\n");
-    printf("  Usage:\n\t%s json_commands\n\n", argv[0]);
-    printf("  Example:\n\t./tests_cmdline '{ \"seed\":{\"source\":\"create\"} }'\n\n" );
-    printf( "See the online API documentation for a list of JSON commands at\ndigitalbitbox.com.\n\n\n");
-}
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+#pragma GCC diagnostic ignored "-Winline"
+#endif
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wmissing-prototypes"
+#pragma clang diagnostic ignored "-Wunused-function"
+#endif
 
 
-int main ( int argc, char *argv[] )
-{
-    if (argc != 2) {
-        usage(argv);
-    } else {
-        random_init();
-        memory_setup();
-        ecc_context_init();
+#define USE_ECMULT_STATIC_PRECOMPUTATION 1
+#define USE_BASIC_CONFIG 1
+#define VERIFY 1
 
-        // A password is required before sending commands.
-        utils_send_print_cmd("{\"password\":\"standard_password\"}", PASSWORD_NONE);
 
-        // Uncomment to test a command that requires a seed
-        //utils_send_print_cmd("{\"seed\":{\"source\":\"create\"}}", PASSWORD_STAND);
+#include "../src/secp256k1/src/basic-config.h"
+#include "../src/secp256k1/src/tests.c"
 
-        // Send the command
-        utils_send_print_cmd(argv[1], PASSWORD_STAND);
-        ecc_context_destroy();
-    }
-    return 0;
-}
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif


### PR DESCRIPTION
Use [bitcoin/secp256k1 ECC library](https://github.com/bitcoin/secp256k1) because it is well reviewed, does signing 6x faster, supports ECDHA and Schnorr which may be useful in future, and is made with sufficient paranoia. The drawback is it is big, about 92kB larger than the current 'micro' uECC library, and the MCU flash space is nearly full. In case space is needed in the future, a flag `ECC_USE_SECP256K1_LIB` allows selecting secp256k1 (default) or uECC.

Notes:
- Unit tests included with secp256k1 are activated in Travis CI.
- The secp256k1 library requires the second half of the signature to use the 'lower-S form', i.e.  the lower half of the range from 0x1 to 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0, inclusive. Therefore, unit tests for signatures in tests_api.c were updated. The reason is given [here](https://github.com/bitcoin/secp256k1/blob/master/include/secp256k1.h#L324-L349).
- Some memory leaks introduced in a recent PR were fixed.
- An executive decision was made to turn verbose off in cmake.
