### PR TITLE
house cleaning, add error codes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,5 +25,7 @@ before_script:
 
 script: 
     - mkdir build && cd build
-    - cmake .. -DCONTINUOUS_INTEGRATION=1 && make
+    - cmake .. -DCONTINUOUS_INTEGRATION=1 -DBUILD_COVERAGE=OFF && make
     - make test
+    - bin/tests_api
+    - bin/tests_unit

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ set(version_file "${CMAKE_CURRENT_SOURCE_DIR}/src/version.h")
 # Options for building
 
 option(BUILD_TESTS "Build the unit tests." ON)
+option(BUILD_COVERAGE "Compile with test coverage flags." OFF)
 option(BUILD_DOCUMENTATION "Build the Doxygen documentation." ON)
 option(CMAKE_VERBOSE_MAKEFILE "Verbose build." OFF)
 option(USE_UECC_LIB "Use micro ECC instead bitcoin's secp256k1 library." OFF)
@@ -45,6 +46,7 @@ endif()
 
 message(STATUS "Verbose:                ${CMAKE_VERBOSE_MAKEFILE}")
 message(STATUS "Testing:                ${BUILD_TESTS}")
+message(STATUS "Coverage:               ${BUILD_COVERAGE}")
 message(STATUS "Documentation:          ${BUILD_DOCUMENTATION}")
 
 
@@ -59,8 +61,8 @@ set(LIBRARY_OUTPUT_PATH  ${CMAKE_CURRENT_BINARY_DIR}/lib)
 # Compiler flags
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os")
 #set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O0 -g") # valgrind
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Os")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -W -Wall -Wextra -Werror -pedantic -Wredundant-decls -Wstrict-prototypes -Wundef -Wshadow -Wpointer-arith -Wmultichar -Wformat-nonliteral -Winit-self -Wformat-security -Wold-style-definition -Wmissing-include-dirs -Wbad-function-cast -Winline -Wnested-externs -Wfloat-equal -Wmissing-declarations -Wswitch-default -Wwrite-strings -Wcast-qual -Wmissing-prototypes")
 
 if(APPLE)
@@ -76,6 +78,15 @@ endif()
 message(STATUS "C Compiler ID: ${CMAKE_C_COMPILER_ID}")
 message(STATUS "C Flags:       ${CMAKE_C_FLAGS}")
 message(STATUS "C link flags:  ${CMAKE_C_LINK_FLAGS}")
+
+
+#-----------------------------------------------------------------------------
+# Test coverage flags
+
+if(BUILD_COVERAGE)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage")
+  set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -fprofile-arcs")
+endif()
 
 
 #-----------------------------------------------------------------------------
@@ -172,6 +183,7 @@ if(USE_UECC_LIB)
     add_definitions(-DECC_USE_UECC_LIB)
 endif()
 
+
 #-----------------------------------------------------------------------------
 # Build source
 
@@ -181,7 +193,8 @@ if(BUILD_TESTS)
   add_subdirectory(tests)
   add_test(NAME tests_unit COMMAND tests_unit)
   add_test(NAME tests_openssl COMMAND tests_openssl 200)
+  add_test(NAME tests_cmdline COMMAND tests_cmdline '{"name":""}')
   add_test(NAME tests_api COMMAND tests_api)
-  add_test(NAME tests_secp256k1 COMMAND tests_secp256k1 4)
+  add_test(NAME tests_secp256k1 COMMAND tests_secp256k1 2)
   enable_testing()
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ set(C-SOURCES
     secp256k1.c
     utils.c
     wallet.c
+    flags.c
 )
 
 set(C-HW-SOURCES

--- a/src/ataes132.h
+++ b/src/ataes132.h
@@ -28,7 +28,9 @@
 #ifndef _AES132_H_
 #define _AES132_H_
 
+
 #include <stdint.h>
+
 
 #define AES_DEVICE_ADDR     0x50u
 #define AES_MEM_ADDR_LEN    2
@@ -39,16 +41,17 @@
 #define AES_TWI_ID          ID_TWI0
 #define AES_TWI_SPEED       10000
 
+
 void aes_init(void);
 uint8_t aes_eeprom_write(uint32_t u32_start_address, uint16_t u16_length,
                          uint8_t const *p_wr_buffer);
 uint32_t aes_eeprom_read(uint32_t u32_start_address, uint16_t u16_length,
                          uint8_t *p_rd_buffer);
 void aes_calculate_crc(uint8_t length, const uint8_t *data, uint8_t *crc);
-void aes_process(uint8_t const *command, uint16_t cmd_len, uint8_t *response_block,
-                 uint16_t response_len);
-void aes_eeprom(uint16_t LEN, uint32_t ADDR, uint8_t *userdata_read,
-                const uint8_t *userdata_write);
+int aes_process(uint8_t const *command, uint16_t cmd_len, uint8_t *response_block,
+                uint16_t response_len);
+int aes_eeprom(uint16_t LEN, uint32_t ADDR, uint8_t *userdata_read,
+               const uint8_t *userdata_write);
 
 
 #endif

--- a/src/commander.h
+++ b/src/commander.h
@@ -39,14 +39,14 @@
 #else
 #define COMMANDER_REPORT_SIZE       2048
 #endif
-
-#define COMMANDER_ARRAY_ELEMENT_MAX  1024
-#define VERIFYPASS_FILENAME         "verification.txt"
+#define COMMANDER_ARRAY_MAX         COMMANDER_REPORT_SIZE
+#define COMMANDER_ARRAY_ELEMENT_MAX 1024
 #define COMMANDER_MAX_ATTEMPTS      15// max attempts before device reset
-
+#define VERIFYPASS_FILENAME         "verification.txt"
 #define AUTOBACKUP_FILENAME         "autobackup_"
 #define AUTOBACKUP_ENCRYPT          "yes"
 #define AUTOBACKUP_NUM              10
+
 
 char *aes_cbc_b64_encrypt(const unsigned char *in, int inlen, int *out_b64len,
                           PASSWORD_ID id);
@@ -54,13 +54,14 @@ char *aes_cbc_b64_decrypt(const unsigned char *in, int inlen, int *decrypt_len,
                           PASSWORD_ID id);
 
 void commander_clear_report(void);
+const char *commander_read_report(void);
+const char *commander_read_array(void);
 void commander_fill_report(const char *attr, const char *val, int err);
 int commander_fill_signature_array(const uint8_t *sig, const uint8_t *pubkey);
 int commander_fill_json_array(const char **key, const char **value, int *type,
                               int cmd);
 void commander_force_reset(void);
 void commander_create_verifypass(void);
-int commander_test_static_functions(void);
 char *commander(const char *command);
 
 

--- a/src/ecc.c
+++ b/src/ecc.c
@@ -144,16 +144,6 @@ int ecc_verify(const uint8_t *public_key, const uint8_t *signature, const uint8_
 }
 
 
-int ecc_verify_double(const uint8_t *public_key, const uint8_t *signature,
-                      const uint8_t *msg, uint32_t msg_len)
-{
-    uint8_t hash[SHA256_DIGEST_LENGTH];
-    sha256_Raw(msg, msg_len, hash);
-    sha256_Raw(hash, SHA256_DIGEST_LENGTH, hash);
-    return ecc_verify_digest(public_key, hash, signature);
-}
-
-
 int ecc_generate_private_key(uint8_t *private_child, const uint8_t *private_master,
                              const uint8_t *z)
 {
@@ -250,13 +240,6 @@ int ecc_verify(const uint8_t *public_key, const uint8_t *signature, const uint8_
                uint32_t msg_len)
 {
     return uECC_verify(public_key, signature, msg, msg_len);
-}
-
-
-int ecc_verify_double(const uint8_t *public_key, const uint8_t *signature,
-                      const uint8_t *msg, uint32_t msg_len)
-{
-    return uECC_verify_double(public_key, signature, msg, msg_len);
 }
 
 

--- a/src/ecc.h
+++ b/src/ecc.h
@@ -39,8 +39,6 @@ int ecc_sign(const uint8_t *private_key, const uint8_t *msg, uint32_t msg_len,
              uint8_t *sig);
 int ecc_sign_double(const uint8_t *privateKey, const uint8_t *msg, uint32_t msg_len,
                     uint8_t *sig);
-int ecc_verify_double(const uint8_t *public_key, const uint8_t *signature,
-                      const uint8_t *msg, uint32_t msg_len);
 int ecc_verify(const uint8_t *public_key, const uint8_t *signature, const uint8_t *msg,
                uint32_t msg_len);
 int ecc_generate_private_key(uint8_t *private_child, const uint8_t *private_master,

--- a/src/flags.c
+++ b/src/flags.c
@@ -25,21 +25,55 @@
 */
 
 
-#ifndef _SHAM_H_
-#define _SHAM_H_
+#include "flags.h"
 
 
-#include <stdint.h>
+#define X(a) #a,
+const char *const CMD_STR[] = { CMD_TABLE };
+#undef X
+
+#define X(a) #a,
+const char *const ATTR_STR[] = { ATTR_TABLE };
+#undef X
+
+#define X(a, b, c) #b,
+const char *const FLAG_CODE[] = { FLAG_TABLE };
+#undef X
+
+#define X(a, b, c) c,
+const char *const FLAG_MSG[] = { FLAG_TABLE };
+#undef X
+
+#define X(a, b, c) #a,
+const char *const FLAG_ID[] = { FLAG_TABLE };
+#undef X
+
+const char *cmd_str(int cmd)
+{
+    return CMD_STR[cmd];
+}
 
 
-void delay_ms(int delay);
-uint8_t sd_write(const char *f, uint16_t f_len, const char *t, uint16_t t_len,
-                 uint8_t replace, int cmd);
-char *sd_load(const char *f, uint16_t f_len, int cmd);
-uint8_t sd_list(int cmd);
-uint8_t sd_erase(int cmd);
-uint8_t touch_button_press(int long_touch);
-uint8_t flash_read_unique_id(uint32_t *serial, uint32_t len);
+const char *attr_str(int attr)
+{
+    return ATTR_STR[attr];
+}
 
 
-#endif
+const char *flag_code(int flag)
+{
+    return FLAG_CODE[flag];
+}
+
+
+const char *flag_msg(int flag)
+{
+    return FLAG_MSG[flag];
+}
+
+
+const char *flag_id(int flag)
+{
+    return FLAG_ID[flag];
+}
+

--- a/src/flags.h
+++ b/src/flags.h
@@ -29,150 +29,188 @@
 #define _FLAGS_H_
 
 
+#define AES_DATA_LEN_MAX 1024// base64 increases size by ~4/3; AES encryption by max 32 char
+#define PASSWORD_LEN_MIN 4
+#define SALT_LEN_MAX     256
+
+
 #define _STRINGIFY(S) #S
 #define STRINGIFY(S) _STRINGIFY(S)
 
-#define GENERATE_STRING(STRING) #STRING,
-#define GENERATE_ENUM_ATTR(ENUM) ATTR_ ## ENUM ## _,
-#define GENERATE_ENUM_CMD(ENUM) CMD_ ## ENUM ## _,
 
-#define FOREACH_CMD(CMD)        \
-  /*    parent commands     */  \
-  /*    requiring touch     */  \
-        CMD(sign)               \
-        CMD(seed)               \
-        CMD(test)               \
-        CMD(password)           \
-        CMD(touchbutton)        \
-  /* placeholder don't move */  \
-        CMD(require_touch)      \
-  /*    parent commands     */  \
-  /*    not requiring touch */  \
-        CMD(led)                \
-        CMD(xpub)               \
-        CMD(name)               \
-        CMD(reset)              \
-        CMD(device)             \
-        CMD(random)             \
-        CMD(backup)             \
-        CMD(aes256cbc)          \
-        CMD(verifypass)         \
-        CMD(ciphertext)         \
-  /*    child commands      */  \
-        CMD(timeout)            \
-        CMD(holdtime)           \
-        CMD(threshold)          \
-        CMD(generate)           \
-        CMD(source)             \
-        CMD(hash)               \
-        CMD(type)               \
-        CMD(data)               \
-        CMD(meta)               \
-        CMD(checkpub)           \
-        CMD(keypath)            \
-        CMD(changekeypath)      \
-        CMD(strength)           \
-        CMD(salt)               \
-        CMD(filename)           \
-        CMD(decrypt)            \
-        CMD(encrypt)            \
-        CMD(pubkey)             \
-        CMD(address)            \
-        CMD(present)            \
-        CMD(sig)                \
-        CMD(pin)                \
-        CMD(echo)               \
-        CMD(value)              \
-        CMD(script)             \
-        CMD(verify_output)      \
-  /* placeholder don't move */  \
-        CMD(none)                /* keep last */
-
-#define FOREACH_ATTR(ATTR)      \
-  /*    command attributes  */  \
-        ATTR(transaction)       \
-        ATTR(hash)              \
-        ATTR(meta)              \
-        ATTR(true)              \
-        ATTR(list)              \
-        ATTR(lock)              \
-        ATTR(erase)             \
-        ATTR(toggle)            \
-        ATTR(pseudo)            \
-        ATTR(create)            \
-        ATTR(export)            \
-        ATTR(serial)            \
-        ATTR(version)           \
-        ATTR(decrypt)           \
-        ATTR(encrypt)           \
-        ATTR(password)          \
-        ATTR(xpub)              \
-        ATTR(info)              \
-        ATTR(__ERASE__)         \
-        ATTR(__FORCE__)         \
-        ATTR(none)               /* keep last */
-
-enum CMD_ENUM { FOREACH_CMD(GENERATE_ENUM_CMD) };
-enum ATTR_ENUM { FOREACH_ATTR(GENERATE_ENUM_ATTR) };
-
-#define CMD_NUM      CMD_none_
-#define ATTR_NUM     ATTR_none_
-
-enum STATUS_FLAGS {
-    DBB_OK, DBB_ERROR, DBB_ERROR_MEM,
-    DBB_VERIFY_ECHO, DBB_VERIFY_SAME, DBB_VERIFY_DIFFERENT,
-    DBB_TOUCHED, DBB_NOT_TOUCHED,
-    DBB_KEY_PRESENT, DBB_KEY_ABSENT,
-    DBB_RESET,
-    DBB_ACCESS_INITIALIZE, DBB_ACCESS_ITERATE,
-    DBB_MEM_ERASED, DBB_MEM_NOT_ERASED,
-    DBB_SD_REPLACE, DBB_SD_NO_REPLACE,
-    DBB_JSON_STRING, DBB_JSON_BOOL, DBB_JSON_NUMBER, DBB_JSON_NONE
-};
+// Command keys
+#define CMD_TABLE \
+/* parent keys  */\
+/*  with touch  */\
+X(seed)           \
+X(sign)           \
+X(password)       \
+/* placeholder  */\
+/* do not move  */\
+X(REQUIRE_TOUCH)  \
+/* parent keys  */\
+/*  w/o touch   */\
+X(led)            \
+X(xpub)           \
+X(name)           \
+X(reset)          \
+X(device)         \
+X(random)         \
+X(backup)         \
+X(aes256cbc)      \
+X(verifypass)     \
+/* placeholder  */\
+/* do not move  */\
+X(END_PARENT)     \
+/*  child keys  */\
+X(source)         \
+X(type)           \
+X(hash)           \
+X(data)           \
+X(meta)           \
+X(salt)           \
+X(pubkey)         \
+X(checkpub)       \
+X(filename)       \
+X(changekeypath)  \
+X(keypath)        \
+X(address)        \
+X(present)        \
+X(decrypt)        \
+X(encrypt)        \
+X(script)         \
+X(value)          \
+X(sig)            \
+X(pin)            \
+/* placeholder  */\
+/* do not move  */\
+X(END_CHILD)      \
+/*  reply keys  */\
+X(ciphertext)     \
+X(echo)           \
+X(2FA)            \
+X(sham)           \
+X(input)          \
+X(ataes)          \
+X(touchbutton)    \
+X(NUM)             /* keep last */
 
 
-#define PASSWORD_LEN_MIN            4
-#define DATA_LEN_MAX                1024/*base64 increases size by ~4/3; AES encryption by max 32 char*/
+// Attributes
+#define ATTR_TABLE \
+X(success)        \
+X(error)          \
+X(yes)            \
+X(transaction)    \
+X(hash)           \
+X(meta)           \
+X(list)           \
+X(lock)           \
+X(decrypt)        \
+X(encrypt)        \
+X(true)           \
+X(false)          \
+X(erase)          \
+X(toggle)         \
+X(pseudo)         \
+X(create)         \
+X(export)         \
+X(xpub)           \
+X(name)           \
+X(info)           \
+X(serial)         \
+X(version)        \
+X(password)       \
+X(__ERASE__)      \
+X(__FORCE__)      \
+X(NUM)             /* keep last */
 
-#define FLAG_ERR_PASSWORD_LEN       "The password length must be at least " STRINGIFY(PASSWORD_LEN_MIN) " characters."
-#define FLAG_ERR_NO_PASSWORD        "Please set a password."
-#define FLAG_ERR_NO_INPUT           "No input received."
-#define FLAG_ERR_DATA_LEN           "Data must be less than " STRINGIFY(DATA_LEN_MAX)" characters."
-#define FLAG_ERR_REPORT_BUFFER      "{\"output\":{\"error\":\"Output report buffer overflow.\"}}"
-#define FLAG_ERR_JSON_PARSE         "JSON parse error."
-#define FLAG_ERR_JSON_BRACKET       "Is the command enclosed by curly brackets?"
-#define FLAG_ERR_INVALID_CMD        "Invalid command."
-#define FLAG_ERR_MULTIPLE_CMD       "Only one command allowed at a time."
-#define FLAG_ERR_RESET              "Too many failed access attempts. Device reset."
-#define FLAG_ERR_RESET_WARNING      "attempts remain before the device is reset."
-#define FLAG_ERR_DEVICE_LOCKED      "Device locked. Erase device to access this command."
-#define FLAG_ERR_BIP32_MISSING      "BIP32 mnemonic not present."
-#define FLAG_ERR_XPUB               "Could not get xpub."
-#define FLAG_ERR_DECRYPT            "Could not decrypt."
-#define FLAG_ERR_MNEMO_CHECK        "Invalid mnemonic."
-#define FLAG_ERR_ADDRESS_LEN        "Incorrect address length. A 34 character address is expected."
-#define FLAG_ERR_SIGN_LEN           "Incorrect hash length. A 32-byte hexadecimal value (64 characters) is expected."
-#define FLAG_ERR_DESERIALIZE        "Could not deserialize outputs or wrong change keypath."
-#define FLAG_ERR_KEY_GEN            "Could not generate key."
-#define FLAG_ERR_SIGN               "Could not sign."
-#define FLAG_ERR_SALT_LEN           "Salt must be less than " STRINGIFY(SALT_LEN_MAX) " characters."
-#define FLAG_ERR_SEED_SD            "Seed creation requires an SD card for automatic encrypted backup of the seed."
-#define FLAG_ERR_SEED_SD_NUM        "Too many backup files. Please remove one from the SD card."
-#define FLAG_ERR_SEED_MEM           "Could not allocate memory for seed."
-#define FLAG_ERR_ENCRYPT_MEM        "Could not encrypt."
-#define FLAG_ERR_ATAES              "Chip communication error."
-#define FLAG_ERR_FLASH              "Could not read flash."
-#define FLAG_ERR_NO_MCU             "Ignored for non-embedded testing."
-#define FLAG_ERR_SD_CARD            "Please insert SD card."
-#define FLAG_ERR_SD_MOUNT           "Could not mount the SD card."
-#define FLAG_ERR_SD_OPEN            "Could not open a file to write - it may already exist."
-#define FLAG_ERR_SD_OPEN_DIR        "Could not open the directory."
-#define FLAG_ERR_SD_FILE_CORRUPT    "Corrupted file."
-#define FLAG_ERR_SD_WRITE           "Could not write the file."
-#define FLAG_ERR_SD_WRITE_LEN       "Text to write is too large."
-#define FLAG_ERR_SD_READ            "Could not read the file."
-#define FLAG_ERR_SD_ERASE           "May not have erased all files (or no file present)."
-#define FLAG_ERR_NUM_FILES          "Too many files to read. The list is truncated."
-#define FLAG_ERR_PASSWORD_ID        "Invalid password ID."
+
+// Status and error flags
+#define FLAG_TABLE \
+X(OK,                    0, 0)\
+X(ERROR,                 0, 0)\
+X(ERROR_MEM,             0, 0)\
+X(VERIFY_ECHO,           0, 0)\
+X(VERIFY_SAME,           0, 0)\
+X(VERIFY_DIFFERENT,      0, 0)\
+X(TOUCHED,               0, 0)\
+X(NOT_TOUCHED,           0, 0)\
+X(KEY_PRESENT,           0, 0)\
+X(KEY_ABSENT,            0, 0)\
+X(RESET,                 0, 0)\
+X(ACCESS_INITIALIZE,     0, 0)\
+X(ACCESS_ITERATE,        0, 0)\
+X(MEM_ERASED,            0, 0)\
+X(MEM_NOT_ERASED,        0, 0)\
+X(SD_REPLACE,            0, 0)\
+X(SD_NO_REPLACE,         0, 0)\
+X(JSON_STRING,           0, 0)\
+X(JSON_BOOL,             0, 0)\
+X(JSON_ARRAY,            0, 0)\
+X(JSON_NUMBER,           0, 0)\
+X(JSON_NONE,             0, 0)\
+/* placeholder don't move  */ \
+X(FLAG_ERROR_START,      0, 0)\
+/* error flags             */ \
+X(ERR_IO_NO_PASSWORD,  101, "Please set a password.")\
+X(ERR_IO_PASSWORD_LEN, 102, "The password length must be at least " STRINGIFY(PASSWORD_LEN_MIN) " characters.")\
+X(ERR_IO_NO_INPUT,     103, "No input received.")\
+X(ERR_IO_INVALID_CMD,  104, "Invalid command.")\
+X(ERR_IO_MULT_CMD,     105, "Only one command allowed at a time.")\
+X(ERR_IO_DATA_LEN,     106, "Data must be less than " STRINGIFY(AES_DATA_LEN_MAX)" characters.")\
+X(ERR_IO_REPORT_BUF,   107, "Output buffer overflow.")\
+X(ERR_IO_DECRYPT,      108, "Could not decrypt.")\
+X(ERR_IO_JSON_PARSE,   109, "JSON parse error.")\
+X(ERR_IO_RESET,        110, "Too many failed access attempts. Device reset.")\
+X(ERR_IO_LOCKED,       111, "Device locked. Erase device to access this command.")\
+X(ERR_SEED_SD,         200, "Seed creation requires an SD card for automatic encrypted backup of the seed.")\
+X(ERR_SEED_SD_NUM,     201, "Too many backup files. Please remove one from the SD card.")\
+X(ERR_SEED_MEM,        202, "Could not allocate memory for seed.")\
+X(ERR_SEED_SALT_LEN,   203, "Salt must be less than " STRINGIFY(SALT_LEN_MAX) " characters.")\
+X(ERR_SEED_INVALID,    204, "Invalid seed.")\
+X(ERR_KEY_MASTER,      250, "Master key not present.")\
+X(ERR_KEY_CHILD,       251, "Could not generate key.")\
+X(ERR_SIGN_ADDR_LEN,   300, "Incorrect address length. A 34 character address is expected.")\
+X(ERR_SIGN_HASH_LEN,   301, "Incorrect hash length. A 32-byte hexadecimal value (64 characters) is expected.")\
+X(ERR_SIGN_DESERIAL,   302, "Could not deserialize outputs or wrong change keypath.")\
+X(ERR_SIGN_ECCLIB,     303, "Could not sign.")\
+X(ERR_SD_CARD,         400, "Please insert SD card.")\
+X(ERR_SD_MOUNT,        401, "Could not mount the SD card.")\
+X(ERR_SD_OPEN_FILE,    402, "Could not open a file to write - it may already exist.")\
+X(ERR_SD_OPEN_DIR,     403, "Could not open the directory.")\
+X(ERR_SD_CORRUPT_FILE, 404, "Corrupted file.")\
+X(ERR_SD_WRITE_FILE,   405, "Could not write the file.")\
+X(ERR_SD_WRITE_LEN,    406, "Text to write is too large.")\
+X(ERR_SD_READ_FILE,    407, "Could not read the file.")\
+X(ERR_SD_ERASE,        408, "May not have erased all files (or no file present).")\
+X(ERR_SD_NUM_FILES,    409, "Too many files to read. The list is truncated.")\
+X(ERR_MEM_ATAES,       500, "Chip communication error.")\
+X(ERR_MEM_FLASH,       501, "Could not read flash.")\
+X(ERR_MEM_ENCRYPT,     502, "Could not encrypt.")\
+X(WARN_RESET,          900, "attempts remain before the device is reset.")\
+X(WARN_NO_MCU,         901, "Ignored for non-embedded testing.")\
+X(FLAG_NUM,              0, 0)/* keep last */
+
+
+#define X(a) CMD_ ## a,
+enum CMD_ENUM { CMD_TABLE };
+#undef X
+
+#define X(a) ATTR_ ## a,
+enum CMD_ATTR_ENUM { ATTR_TABLE };
+#undef X
+
+#define X(a, b, c) DBB_ ## a,
+enum FLAG_ENUM { FLAG_TABLE };
+#undef X
+
+
+const char *cmd_str(int cmd);
+const char *attr_str(int attr);
+const char *flag_code(int flag);
+const char *flag_msg(int flag);
+const char *flag_id(int flag);
+
 
 #endif

--- a/src/led.c
+++ b/src/led.c
@@ -54,16 +54,6 @@ int ioport_get_pin_level(int led)
 #endif
 
 
-void led_off(void)
-{
-    ioport_set_pin_level(LED_0_PIN, IOPORT_PIN_LEVEL_HIGH);
-}
-
-void led_on(void)
-{
-    ioport_set_pin_level(LED_0_PIN, IOPORT_PIN_LEVEL_LOW);
-}
-
 void led_toggle(void)
 {
     ioport_set_pin_level(LED_0_PIN, !ioport_get_pin_level(LED_0_PIN));

--- a/src/led.h
+++ b/src/led.h
@@ -25,12 +25,11 @@
 */
 
 
-
 #ifndef _LED_H_
 #define _LED_H_
 
-void led_off(void);
-void led_on(void);
+
 void led_toggle(void);
+
 
 #endif

--- a/src/memory.h
+++ b/src/memory.h
@@ -62,9 +62,9 @@ typedef enum PASSWORD_ID {
 } PASSWORD_ID;
 
 
+int memory_setup(void);
 void memory_erase(void);
 void memory_erase_seed(void);
-void memory_setup(void);
 void memory_clear_variables(void);
 void memory_mempass(void);
 

--- a/src/sd.h
+++ b/src/sd.h
@@ -28,10 +28,10 @@
 #ifndef _SD_H_
 #define _SD_H_
 
-uint8_t sd_list(void);
-uint8_t sd_erase(void);
-char *sd_load(const char *f, uint16_t f_len);
+uint8_t sd_list(int cmd);
+uint8_t sd_erase(int cmd);
+char *sd_load(const char *f, uint16_t f_len, int cmd);
 uint8_t sd_write(const char *f, uint16_t f_len, const char *text, uint16_t t_len,
-                 uint8_t replace);
+                 uint8_t replace, int cmd);
 
 #endif

--- a/src/sha2.c
+++ b/src/sha2.c
@@ -256,18 +256,6 @@ static const sha2_word64 K512[80] = {
     0x5fcb6fab3ad6faecULL, 0x6c44198c4a475817ULL
 };
 
-/* Initial hash value H for SHA-384 */
-/*static const sha2_word64 sha384_initial_hash_value[8] = {
-    0xcbbb9d5dc1059ed8ULL,
-    0x629a292a367cd507ULL,
-    0x9159015a3070dd17ULL,
-    0x152fecd8f70e5939ULL,
-    0x67332667ffc00b31ULL,
-    0x8eb44a8768581511ULL,
-    0xdb0c2e0d64f98fa7ULL,
-    0x47b5481dbefa4fa4ULL
-};*/
-
 /* Initial hash value H for SHA-512 */
 static const sha2_word64 sha512_initial_hash_value[8] = {
     0x6a09e667f3bcc908ULL,
@@ -279,12 +267,6 @@ static const sha2_word64 sha512_initial_hash_value[8] = {
     0x1f83d9abfb41bd6bULL,
     0x5be0cd19137e2179ULL
 };
-
-/*
- * Constant used by SHA256/384/512_End() functions for converting the
- * digest to a readable hexadecimal character string:
- */
-static const char *sha2_hex_digits = "0123456789abcdef";
 
 
 /*** SHA-256: *********************************************************/
@@ -583,41 +565,12 @@ void sha256_Final(sha2_byte digest[], SHA256_CTX *context)
     usedspace = 0;
 }
 
-char *sha256_End(SHA256_CTX *context, char buffer[])
-{
-    sha2_byte   digest[SHA256_DIGEST_LENGTH], *d = digest;
-
-    if (buffer != (char *)0) {
-        sha256_Final(digest, context);
-
-        for (int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
-            *buffer++ = sha2_hex_digits[(*d & 0xf0) >> 4];
-            *buffer++ = sha2_hex_digits[*d & 0x0f];
-            d++;
-        }
-        *buffer = (char)0;
-    } else {
-        MEMSET_BZERO(context, sizeof(SHA256_CTX));
-    }
-    MEMSET_BZERO(digest, SHA256_DIGEST_LENGTH);
-    return buffer;
-}
-
 void sha256_Raw(const sha2_byte *data, size_t len, uint8_t digest[SHA256_DIGEST_LENGTH])
 {
     SHA256_CTX  context;
     sha256_Init(&context);
     sha256_Update(&context, data, len);
     sha256_Final(digest, &context);
-}
-
-char *sha256_Data(const sha2_byte *data, size_t len,
-                  char digest[SHA256_DIGEST_STRING_LENGTH])
-{
-    SHA256_CTX  context;
-    sha256_Init(&context);
-    sha256_Update(&context, data, len);
-    return sha256_End(&context, digest);
 }
 
 
@@ -921,40 +874,10 @@ void sha512_Final(sha2_byte digest[], SHA512_CTX *context)
     MEMSET_BZERO(context, sizeof(SHA512_CTX));
 }
 
-char *sha512_End(SHA512_CTX *context, char buffer[])
-{
-    sha2_byte   digest[SHA512_DIGEST_LENGTH], *d = digest;
-
-    if (buffer != (char *)0) {
-        sha512_Final(digest, context);
-
-        for (int i = 0; i < SHA512_DIGEST_LENGTH; i++) {
-            *buffer++ = sha2_hex_digits[(*d & 0xf0) >> 4];
-            *buffer++ = sha2_hex_digits[*d & 0x0f];
-            d++;
-        }
-        *buffer = (char)0;
-    } else {
-        MEMSET_BZERO(context, sizeof(SHA512_CTX));
-    }
-    MEMSET_BZERO(digest, SHA512_DIGEST_LENGTH);
-    return buffer;
-}
-
 void sha512_Raw(const sha2_byte *data, size_t len, uint8_t digest[SHA512_DIGEST_LENGTH])
 {
     SHA512_CTX  context;
     sha512_Init(&context);
     sha512_Update(&context, data, len);
     sha512_Final(digest, &context);
-}
-
-char *sha512_Data(const sha2_byte *data, size_t len,
-                  char digest[SHA512_DIGEST_STRING_LENGTH])
-{
-    SHA512_CTX  context;
-
-    sha512_Init(&context);
-    sha512_Update(&context, data, len);
-    return sha512_End(&context, digest);
 }

--- a/src/sha2.h
+++ b/src/sha2.h
@@ -55,15 +55,11 @@ typedef struct _SHA512_CTX {
 void sha256_Init(SHA256_CTX *);
 void sha256_Update(SHA256_CTX *, const uint8_t *, size_t);
 void sha256_Final(uint8_t[SHA256_DIGEST_LENGTH], SHA256_CTX *);
-char *sha256_End(SHA256_CTX *, char[SHA256_DIGEST_STRING_LENGTH]);
 void sha256_Raw(const uint8_t *, size_t, uint8_t[SHA256_DIGEST_LENGTH]);
-char *sha256_Data(const uint8_t *, size_t, char[SHA256_DIGEST_STRING_LENGTH]);
 
 void sha512_Init(SHA512_CTX *);
 void sha512_Update(SHA512_CTX *, const uint8_t *, size_t);
 void sha512_Final(uint8_t[SHA512_DIGEST_LENGTH], SHA512_CTX *);
-char *sha512_End(SHA512_CTX *, char[SHA512_DIGEST_STRING_LENGTH]);
 void sha512_Raw(const uint8_t *, size_t, uint8_t[SHA512_DIGEST_LENGTH]);
-char *sha512_Data(const uint8_t *, size_t, char[SHA512_DIGEST_STRING_LENGTH]);
 
 #endif

--- a/src/sham.c
+++ b/src/sham.c
@@ -29,8 +29,8 @@
 #include <stdio.h>
 
 #include "sham.h"
-#include "commander.h"
 #include "flags.h"
+#include "commander.h"
 
 
 static char sd_filename[64] = {0};
@@ -43,23 +43,25 @@ void delay_ms(int delay)
 
 
 uint8_t sd_write(const char *f, uint16_t f_len, const char *t, uint16_t t_len,
-                 uint8_t replace)
+                 uint8_t replace, int cmd)
 {
+    (void) cmd;
     (void) replace;
     memset(sd_filename, 0, sizeof(sd_filename));
     memset(sd_text, 0, sizeof(sd_text));
     snprintf(sd_filename, sizeof(sd_filename), "%.*s", f_len, f);
     snprintf(sd_text, sizeof(sd_text), "%.*s", t_len, t);
-    commander_fill_report("sd_write", FLAG_ERR_NO_MCU, DBB_OK);
+    commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
     return DBB_OK;
 }
 
 
-char *sd_load(const char *f, uint16_t f_len)
+char *sd_load(const char *f, uint16_t f_len, int cmd)
 {
-    static char text[512];
-    memcpy(text, sd_text, 512);
-    commander_fill_report("sd_load", FLAG_ERR_NO_MCU, DBB_OK);
+    (void) cmd;
+    static char text[sizeof(sd_text)];
+    memcpy(text, sd_text, sizeof(sd_text));
+    commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
     if (!strncmp(sd_filename, f, f_len)) {
         return text;
     }
@@ -67,19 +69,20 @@ char *sd_load(const char *f, uint16_t f_len)
 }
 
 
-uint8_t sd_list(void)
+uint8_t sd_list(int cmd)
 {
-    commander_fill_report("sd_list", FLAG_ERR_NO_MCU, DBB_OK);
+    commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
     if (sd_filename[0]) {
-        commander_fill_report("backup", sd_filename, DBB_OK);
+        commander_fill_report(cmd_str(cmd), sd_filename, DBB_OK);
     }
     return DBB_OK;
 }
 
 
-uint8_t sd_erase(void)
+uint8_t sd_erase(int cmd)
 {
-    commander_fill_report("sd_erase", FLAG_ERR_NO_MCU, DBB_OK);
+    (void) cmd;
+    commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
     memset(sd_filename, 0, sizeof(sd_filename));
     memset(sd_text, 0, sizeof(sd_text));
     return DBB_OK;
@@ -89,7 +92,7 @@ uint8_t sd_erase(void)
 uint8_t touch_button_press(int long_touch)
 {
     (void) long_touch;
-    commander_fill_report("touchbutton", FLAG_ERR_NO_MCU, DBB_OK);
+    commander_fill_report(cmd_str(CMD_touchbutton), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
     return DBB_TOUCHED;
 }
 

--- a/src/touch.c
+++ b/src/touch.c
@@ -148,13 +148,13 @@ uint8_t touch_button_press(int long_touch)
         led_off();
 
     } else {
-        sprintf(message, "Touchbutton timed out. (%d/%d)",
-                qt_measure_data.channel_signals[QTOUCH_TOUCH_CHANNEL],
-                qt_measure_data.channel_references[QTOUCH_TOUCH_CHANNEL]);
+        snprintf(message, sizeof(message), "Touchbutton timed out. (%d/%d)",
+                 qt_measure_data.channel_signals[QTOUCH_TOUCH_CHANNEL],
+                 qt_measure_data.channel_references[QTOUCH_TOUCH_CHANNEL]);
         status = DBB_ERROR;
         led_off();
     }
 
-    commander_fill_report("touchbutton", message, status);
+    commander_fill_report(cmd_str(CMD_touchbutton), message, status);
     return pushed;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -34,9 +34,7 @@
 #include "commander.h"
 #include "yajl/src/api/yajl_tree.h"
 
-extern const char *CMD_STR[];
-static char PIN_2FA[5] = {0};
-static char decrypted_report[COMMANDER_REPORT_SIZE];
+
 static uint8_t buffer_hex_to_uint8[TO_UINT8_HEX_BUF_LEN];
 static char buffer_uint8_to_hex[TO_UINT8_HEX_BUF_LEN];
 
@@ -176,7 +174,12 @@ int utils_varint_to_uint64(const char *vi, uint64_t *i)
 }
 
 
-char *utils_read_decrypted_report(void)
+#ifdef TESTING
+
+static char PIN_2FA[5] = {0};
+static char decrypted_report[COMMANDER_REPORT_SIZE];
+
+const char *utils_read_decrypted_report(void)
 {
     return decrypted_report;
 }
@@ -199,7 +202,7 @@ void utils_decrypt_report(const char *report)
 
     size_t i, r = json_node->u.object.len;
     for (i = 0; i < r; i++) {
-        const char *ciphertext_path[] = { CMD_STR[CMD_ciphertext_], (const char *) 0 };
+        const char *ciphertext_path[] = { cmd_str(CMD_ciphertext), (const char *) 0 };
         const char *echo_path[] = { "echo", (const char *) 0 };
         const char *ciphertext = YAJL_GET_STRING(yajl_tree_get(json_node, ciphertext_path,
                                  yajl_t_string));
@@ -248,7 +251,7 @@ void utils_decrypt_report(const char *report)
             pin_report[decrypt_len] = '\0';
             yajl_val pin_node = yajl_tree_parse(pin_report, NULL, 0);
 
-            const char *pin_path[] = { CMD_STR[CMD_pin_], (const char *) 0 };
+            const char *pin_path[] = { cmd_str(CMD_pin), (const char *) 0 };
             pin = YAJL_GET_STRING(yajl_tree_get(pin_node, pin_path, yajl_t_string));
             if (pin) {
                 memcpy(PIN_2FA, pin, 4);
@@ -286,14 +289,11 @@ void utils_send_cmd(const char *command, PASSWORD_ID enc_id)
 }
 
 
-#ifdef TESTING
-
 void utils_send_print_cmd(const char *command, PASSWORD_ID enc_id)
 {
     printf("\nutils send:   %s\n", command);
     utils_send_cmd(command, enc_id);
     printf("utils recv:   %s\n\n", decrypted_report);
 }
-
 
 #endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -33,23 +33,23 @@
 #include <stddef.h>
 #include "memory.h"
 
+
 #define TO_UINT8_HEX_BUF_LEN 2048
 #define VARINT_LEN 20
 
 #define strlens(s) (s == NULL ? 0 : strlen(s))
 
+
 void utils_clear_buffers(void);
 uint8_t *utils_hex_to_uint8(const char *str);
 char *utils_uint8_to_hex(const uint8_t *bin, size_t l);
-
 void utils_reverse_hex(char *h, int len);
 void utils_uint64_to_varint(char *vi, int *l, uint64_t i);
 int utils_varint_to_uint64(const char *vi, uint64_t *i);
-
-char *utils_read_decrypted_report(void);
+#ifdef TESTING
+const char *utils_read_decrypted_report(void);
 void utils_decrypt_report(const char *report);
 void utils_send_cmd(const char *instruction, PASSWORD_ID enc_id);
-#ifdef TESTING
 void utils_send_print_cmd(const char *command, PASSWORD_ID enc_id);
 #endif
 

--- a/src/version.h
+++ b/src/version.h
@@ -28,6 +28,6 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-const char *DIGITAL_BITBOX_VERSION = "v1.1-20-g60032f3";
+const char *DIGITAL_BITBOX_VERSION = "v1.1-23-g5665777";
 
 #endif

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -36,28 +36,24 @@
 
 #define BIP39_PBKDF2_ROUNDS 2048
 #define MAX_SEED_WORDS      25// 24 mnemonic words + 1 for NULL ending
-#define SALT_LEN_MAX        256// 24 mnemonic words + 1 for NULL ending
 
 
 /* BIP32 */
 int wallet_split_seed(char **seed_words, const char *message);
-const char *const *wallet_mnemonic_wordlist(void);
-int wallet_master_from_xpriv(char *src, int src_len);
-int wallet_master_from_mnemonic(char *mnemo, int m_len, const char *salt, int s_len);
-int wallet_check_pubkey(const char *pubkeyhash, const char *keypath, int keypath_len);
-int wallet_sign(const char *message, int msg_len, const char *keypath, int keypath_len,
-                int to_hash);
-void wallet_report_xpriv(const char *keypath, int keypath_len, char *xpub);
-void wallet_report_xpub(const char *keypath, int keypath_len, char *xpub);
-int wallet_generate_key(HDNode *node, const char *keypath, int keypath_len,
-                        const uint8_t *privkeymaster, const uint8_t *chaincode);
+int wallet_master_from_xpriv(char *src);
+int wallet_master_from_mnemonic(char *mnemo, const char *salt);
+int wallet_check_pubkey(const char *pubkeyhash, const char *keypath);
+int wallet_sign(const char *message, const char *keypath, int to_hash);
+void wallet_report_xpriv(const char *keypath, char *xpub);
+void wallet_report_xpub(const char *keypath, char *xpub);
+int wallet_generate_key(HDNode *node, const char *keypath, const uint8_t *privkeymaster,
+                        const uint8_t *chaincode);
 char *wallet_mnemonic_from_data(const uint8_t *data, int len);
 int wallet_mnemonic_check(const char *mnemo);
 void wallet_mnemonic_to_seed(const char *mnemo, const char *passphrase,
-                             uint8_t s[512 / 8],
-                             void (*progress_callback)(uint32_t current, uint32_t total));
+                             uint8_t s[512 / 8], void (*progress_callback)(uint32_t current, uint32_t total));
 int wallet_get_outputs(const char *tx, uint64_t tx_len, char *outputs, int outputs_len);
-int wallet_deserialize_output(char *outputs, const char *keypath, int keypath_len);
+int wallet_deserialize_output(char *outputs, const char *keypath);
 /* Bitcoin formats */
 void wallet_get_pubkeyhash(const uint8_t *pub_key, uint8_t *pubkeyhash);
 void wallet_get_address_raw(const uint8_t *pub_key, uint8_t version, uint8_t *addr_raw);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,9 +22,15 @@ target_link_libraries(tests_cmdline bitbox)
 
 
 #-----------------------------------------------------------------------------
-# Build tests for secp256k1
+# Build secp256k1 submodule tests
 add_executable(tests_secp256k1 tests_secp256k1.c)
 target_link_libraries(tests_secp256k1 bitbox)
+
+
+#-----------------------------------------------------------------------------
+# Build yajl submodule tests
+add_executable(tests_yajl tests_yajl.c)
+target_link_libraries(tests_yajl bitbox)
 
 
 #-----------------------------------------------------------------------------

--- a/tests/tests_cmdline.c
+++ b/tests/tests_cmdline.c
@@ -44,7 +44,7 @@ static void usage(char *argv[])
 }
 
 
-int main ( int argc, char *argv[] )
+int main(int argc, char *argv[])
 {
     if (argc != 2) {
         usage(argv);

--- a/tests/tests_unit.c
+++ b/tests/tests_unit.c
@@ -98,7 +98,7 @@ static void test_bip32_vector_1(void)
 
     // [Chain m/0']
     char path0[] = "m/0'";
-    wallet_generate_key(&node, path0, strlen(path0), private_key_master, chain_code_master);
+    wallet_generate_key(&node, path0, private_key_master, chain_code_master);
     u_assert_int_eq(node.fingerprint, 0x3442193e);
     u_assert_mem_eq(node.chain_code,
                     utils_hex_to_uint8("47fdacbd0f1097043b78c63c20c34ef4ed9a111d980047ad16282c7ae6236141"),
@@ -127,7 +127,7 @@ static void test_bip32_vector_1(void)
 
     // [Chain m/0'/1]
     char path1[] = "m/0'/1";
-    wallet_generate_key(&node, path1, strlen(path1), private_key_master, chain_code_master);
+    wallet_generate_key(&node, path1, private_key_master, chain_code_master);
     u_assert_int_eq(node.fingerprint, 0x5c1bd648);
     u_assert_mem_eq(node.chain_code,
                     utils_hex_to_uint8("2a7857631386ba23dacac34180dd1983734e444fdbf774041578e9b6adb37c19"),
@@ -155,7 +155,7 @@ static void test_bip32_vector_1(void)
 
     // [Chain m/0'/1/2']
     char path2[] = "m/0'/1/2'";
-    wallet_generate_key(&node, path2, strlen(path2), private_key_master, chain_code_master);
+    wallet_generate_key(&node, path2, private_key_master, chain_code_master);
     u_assert_int_eq(node.fingerprint, 0xbef5a2f9);
     u_assert_mem_eq(node.chain_code,
                     utils_hex_to_uint8("04466b9cc8e161e966409ca52986c584f07e9dc81f735db683c3ff6ec7b1503f"),
@@ -183,7 +183,7 @@ static void test_bip32_vector_1(void)
 
     // [Chain m/0'/1/2'/2]
     char path3[] = "m/0'/1/2'/2";
-    wallet_generate_key(&node, path3, strlen(path3), private_key_master, chain_code_master);
+    wallet_generate_key(&node, path3, private_key_master, chain_code_master);
     u_assert_int_eq(node.fingerprint, 0xee7ab90c);
     u_assert_mem_eq(node.chain_code,
                     utils_hex_to_uint8("cfb71883f01676f587d023cc53a35bc7f88f724b1f8c2892ac1275ac822a3edd"),
@@ -211,7 +211,7 @@ static void test_bip32_vector_1(void)
 
     // [Chain m/0'/1/2'/2/1000000000]
     char path4[] = "m/0'/1/2'/2/1000000000";
-    wallet_generate_key(&node, path4, strlen(path4), private_key_master, chain_code_master);
+    wallet_generate_key(&node, path4, private_key_master, chain_code_master);
     u_assert_int_eq(node.fingerprint, 0xd880d7d8);
     u_assert_mem_eq(node.chain_code,
                     utils_hex_to_uint8("c783e67b921d2beb8f6b389cc646d7263b4145701dadd2161548a8b078e65e9e"),
@@ -283,7 +283,7 @@ static void test_bip32_vector_2(void)
 
     // [Chain m/0]
     char path0[] = "m/0";
-    wallet_generate_key(&node, path0, strlen(path0), private_key_master, chain_code_master);
+    wallet_generate_key(&node, path0, private_key_master, chain_code_master);
     u_assert_int_eq(node.fingerprint, 0xbd16bee5);
     u_assert_mem_eq(node.chain_code,
                     utils_hex_to_uint8("f0909affaa7ee7abe5dd4e100598d4dc53cd709d5a5c2cac40e7412f232f7c9c"),
@@ -311,7 +311,7 @@ static void test_bip32_vector_2(void)
 
     // [Chain m/0/2147483647']
     char path1[] = "m/0/2147483647'";
-    wallet_generate_key(&node, path1, strlen(path1), private_key_master, chain_code_master);
+    wallet_generate_key(&node, path1, private_key_master, chain_code_master);
     u_assert_int_eq(node.fingerprint, 0x5a61ff8e);
     u_assert_mem_eq(node.chain_code,
                     utils_hex_to_uint8("be17a268474a6bb9c61e1d720cf6215e2a88c5406c4aee7b38547f585c9a37d9"),
@@ -339,7 +339,7 @@ static void test_bip32_vector_2(void)
 
     // [Chain m/0/2147483647'/1]
     char path2[] = "m/0/2147483647'/1";
-    wallet_generate_key(&node, path2, strlen(path2), private_key_master, chain_code_master);
+    wallet_generate_key(&node, path2, private_key_master, chain_code_master);
     u_assert_int_eq(node.fingerprint, 0xd8ab4937);
     u_assert_mem_eq(node.chain_code,
                     utils_hex_to_uint8("f366f48f1ea9f2d1d3fe958c95ca84ea18e4c4ddb9366c336c927eb246fb38cb"),
@@ -367,7 +367,7 @@ static void test_bip32_vector_2(void)
 
     // [Chain m/0/2147483647'/1/2147483646']
     char path3[] = "m/0/2147483647'/1/2147483646'";
-    wallet_generate_key(&node, path3, strlen(path3), private_key_master, chain_code_master);
+    wallet_generate_key(&node, path3, private_key_master, chain_code_master);
     u_assert_int_eq(node.fingerprint, 0x78412e3a);
     u_assert_mem_eq(node.chain_code,
                     utils_hex_to_uint8("637807030d55d01f9a0cb3a7839515d796bd07706386a6eddf06cc29a65a0e29"),
@@ -395,7 +395,7 @@ static void test_bip32_vector_2(void)
 
     // [Chain m/0/2147483647'/1/2147483646'/2]
     char path4[] = "m/0/2147483647'/1/2147483646'/2";
-    wallet_generate_key(&node, path4, strlen(path4), private_key_master, chain_code_master);
+    wallet_generate_key(&node, path4, private_key_master, chain_code_master);
     u_assert_int_eq(node.fingerprint, 0x31a507b8);
     u_assert_mem_eq(node.chain_code,
                     utils_hex_to_uint8("9452b549be8cea3ecb7a84bec10dcfd94afe4d129ebfd3b3cb58eedf394ed271"),
@@ -1098,9 +1098,91 @@ static void test_base64(void)
 }
 
 
-static void test_commander_static_functions(void)
+static void test_buffer_overflow(void)
 {
-    u_assert_int_eq(commander_test_static_functions(), 0);
+    __extension__ char val[] = { [0 ... COMMANDER_REPORT_SIZE + 2] = '1' };
+
+    commander_clear_report();
+    const char *key[] = {"testing", 0};
+    const char *value[] = {val, 0};
+    int t[] = {DBB_JSON_STRING, DBB_JSON_NONE};
+    commander_fill_json_array(key, value, t, CMD_data);
+    u_assert_str_has(commander_read_report(), flag_msg(DBB_ERR_IO_REPORT_BUF));
+
+    commander_clear_report();
+    commander_fill_report("testing", val, DBB_OK);
+    u_assert_str_has(commander_read_report(), flag_msg(DBB_ERR_IO_REPORT_BUF));
+
+    uint8_t sig[64] = {0};
+    uint8_t pubkey[33] = {0};
+    commander_clear_report();
+    val[COMMANDER_REPORT_SIZE - sizeof(sig) - sizeof(pubkey) - strlens(flag_msg(
+                DBB_ERR_IO_REPORT_BUF))] = '\0';
+    commander_fill_report("testing", val, DBB_OK);
+    commander_fill_signature_array(sig, pubkey);
+    commander_fill_report("sign", commander_read_array(), DBB_OK);
+    u_assert_str_has(commander_read_report(), flag_msg(DBB_ERR_IO_REPORT_BUF));
+}
+
+
+static void test_utils(void)
+{
+    // hex conversion
+    uint8_t uppercase[12];
+    uint8_t lowercase[12];
+    uint8_t *binary;
+    binary = utils_hex_to_uint8("ABCDEF");
+    memcpy(uppercase, binary, 12);
+    binary = utils_hex_to_uint8("abcdef");
+    memcpy(lowercase, binary, 12);
+    u_assert_mem_eq(uppercase, lowercase, 12);
+
+    // overflow
+    char overflow[TO_UINT8_HEX_BUF_LEN + 2];
+    memset(overflow, 'a', sizeof(overflow));
+    overflow[TO_UINT8_HEX_BUF_LEN + 1] = '\0';
+    binary = (uint8_t *)overflow;
+    u_assert_int_eq(1, (binary != NULL));
+    binary = utils_hex_to_uint8(overflow);
+    u_assert_int_eq(1, (binary == NULL));
+
+    binary = (uint8_t *)overflow;
+    u_assert_int_eq(1, (binary != NULL));
+    binary = (uint8_t *)utils_uint8_to_hex((uint8_t *)overflow, TO_UINT8_HEX_BUF_LEN / 2);
+    u_assert_int_eq(1, (binary == NULL));
+
+    // varint conversion
+    uint64_t *I_p;
+    const char **VI_p;
+    uint64_t I[] = {0x05, 0x32, 0xfc, 0xfd, 0xff, 0xfffe, 0xffff, 0x10000, 0x100000, 0xffffffff, 0x100000000, 0xffffffffff, 0};
+    static const char *VI[] = {"05", "32", "fc", "fdfd00", "fdff00", "fdfeff", "fdffff", "fe00000100", "fe00001000", "feffffffff", "ff0000000001000000", "ffffffffffff000000", 0};
+
+    I_p = I;
+    VI_p = VI;
+    while (*I_p && *VI_p) {
+        int l;
+        static char vi[VARINT_LEN];
+        char *vi_p = vi;
+        memset(vi, 0, sizeof(vi));
+
+        utils_uint64_to_varint(vi_p, &l, *I_p);
+        u_assert_str_eq(vi, *VI_p);
+
+        I_p++;
+        VI_p++;
+    }
+
+    I_p = I;
+    VI_p = VI;
+    while (*I_p && *VI_p) {
+        uint64_t i = 0;
+
+        utils_varint_to_uint64(*VI_p, &i);
+        u_assert_int_eq(i, *I_p);
+
+        I_p++;
+        VI_p++;
+    }
 }
 
 
@@ -1121,7 +1203,8 @@ int main(void)
     u_run_test(test_pbkdf2_hmac_sha512);
     u_run_test(test_mnemonic);
     u_run_test(test_mnemonic_check);
-    u_run_test(test_commander_static_functions);
+    u_run_test(test_buffer_overflow);
+    u_run_test(test_utils);
 #ifdef ECC_USE_UECC_LIB
     // unit tests for secp256k1 rfc6979 are in tests_secp256k1.c
     u_run_test(test_rfc6979);
@@ -1129,10 +1212,10 @@ int main(void)
 
     if (!U_TESTS_FAIL) {
         printf("\nALL %i TESTS PASSED\n\n", U_TESTS_RUN);
+    } else {
+        printf("\n%i of %i TESTS PASSED\n\n", U_TESTS_RUN - U_TESTS_FAIL, U_TESTS_RUN);
     }
 
     ecc_context_destroy();
     return U_TESTS_FAIL;
 }
-
-

--- a/tests/tests_yajl.c
+++ b/tests/tests_yajl.c
@@ -25,21 +25,14 @@
 */
 
 
-#ifndef _SHAM_H_
-#define _SHAM_H_
+#include <stdio.h>
+#include <stdlib.h>
 
 
-#include <stdint.h>
-
-
-void delay_ms(int delay);
-uint8_t sd_write(const char *f, uint16_t f_len, const char *t, uint16_t t_len,
-                 uint8_t replace, int cmd);
-char *sd_load(const char *f, uint16_t f_len, int cmd);
-uint8_t sd_list(int cmd);
-uint8_t sd_erase(int cmd);
-uint8_t touch_button_press(int long_touch);
-uint8_t flash_read_unique_id(uint32_t *serial, uint32_t len);
-
-
-#endif
+int main(void)
+{
+    // The submodule must be built in order to run the yajl tests. See:
+    // https://github.com/digitalbitbox/yajl/blob/master/BUILDING
+    const char command[] = "cd ../src/yajl/test/parsing/; ./run_tests.sh";
+    return system(command);
+}

--- a/tests/utest.h
+++ b/tests/utest.h
@@ -75,7 +75,6 @@
 
 #ifndef _UTEST_H_
 #define _UTEST_H_
-
 #include <stdio.h>
 #include <string.h>
 
@@ -90,20 +89,55 @@
  int r_ = (R); \
  int e_ = (E); \
  do { if (r_!=e_) { \
-  printf("FAILED - %s:%d - %s()\n", __FILE__, __LINE__, __func__);\
-  printf("\tExpected:\t%d\n", e_);\
-  printf("\tReceived:\t%d\n", r_);\
-  U_TESTS_FAIL++; }; \
+  printf("FAILED - %s() - Line %d\n", __func__, __LINE__);\
+  printf("\tExpect: \t%d\n", e_);\
+  printf("\tReceive:\t%d\n", r_);\
+  U_TESTS_FAIL++;\
+  return; }; \
  } while(0); }
 
 #define u_assert_str_eq(R,E) {\
  const char * r_ = (R); \
  const char * e_ = (E); \
  do { if (strcmp(r_,e_)) { \
-  printf("FAILED - %s:%d - %s()\n", __FILE__, __LINE__, __func__);\
-  printf("\tExpected:\t%s\n", e_);\
-  printf("\tReceived:\t%s\n", r_);\
-  U_TESTS_FAIL++; }; \
+  printf("FAILED - %s() - Line %d\n", __func__, __LINE__);\
+  printf("\tExpect: \t%s\n", e_);\
+  printf("\tReceive:\t%s\n", r_);\
+  U_TESTS_FAIL++;\
+  return; }; \
+ } while(0); }
+
+#define u_assert_str_not_eq(R,E) {\
+ const char * r_ = (R); \
+ const char * e_ = (E); \
+ do { if (!strcmp(r_,e_)) { \
+  printf("FAILED - %s() - Line %d\n", __func__, __LINE__);\
+  printf("\tNot expect:\t%s\n", e_);\
+  printf("\tReceive:\t%s\n", r_);\
+  U_TESTS_FAIL++;\
+  return; }; \
+ } while(0); }
+
+#define u_assert_str_has(R,E) {\
+ const char * r_ = (R); \
+ const char * e_ = (E); \
+ do { if (!strstr(r_,e_)) { \
+  printf("FAILED - %s() - Line %d\n", __func__, __LINE__);\
+  printf("\tExpect: \t%s\n", e_);\
+  printf("\tReceive:\t%s\n", r_);\
+  U_TESTS_FAIL++;\
+  return; }; \
+ } while(0); }
+
+#define u_assert_str_has_not(R,E) {\
+ const char * r_ = (R); \
+ const char * e_ = (E); \
+ do { if (strstr(r_,e_)) { \
+  printf("FAILED - %s() - Line %d\n", __func__, __LINE__);\
+  printf("\tNot expect:\t%s\n", e_);\
+  printf("\tReceive:\t%s\n", r_);\
+  U_TESTS_FAIL++;\
+  return; }; \
  } while(0); }
 
 #define u_assert_mem_eq(R,E,L) {\
@@ -111,10 +145,11 @@
  const void * e_ = (E); \
  size_t l_ = (L); \
  do { if (memcmp(r_,e_,l_)) { \
-  printf("FAILED - %s:%d - %s()\n", __FILE__, __LINE__, __func__);\
-  printf("\tExpected:\t%s\n", utils_uint8_to_hex(e_,l_));\
-  printf("\tReceived:\t%s\n", utils_uint8_to_hex(r_,l_));\
-  U_TESTS_FAIL++; }; \
+  printf("FAILED - %s() - Line %d\n", __func__, __LINE__);\
+  printf("\tExpect: \t%s\n", utils_uint8_to_hex(e_,l_));\
+  printf("\tReceive:\t%s\n", utils_uint8_to_hex(r_,l_));\
+  U_TESTS_FAIL++;\
+  return; }; \
  } while(0); }
 
 extern int U_TESTS_RUN;


### PR DESCRIPTION
#### Add error codes; fixes #51. 

For example:

**send**
```
{ "password": "abc" }
```

**reply**
```
{
"error": 
    {
    "message": "The password length must be at least 4 characters.", 
    "code": 102,
    "command": "password"
    }
}
```

**error codes** (a macro prefixes `DBB_` to each)
```
#define FLAG_TABLE \
X(ERR_IO_NO_PASSWORD,  101, "Please set a password.")\
X(ERR_IO_PASSWORD_LEN, 102, "The password length must be at least " STRINGIFY(PASSWORD_LEN_MIN) " characters.")\
X(ERR_IO_NO_INPUT,     103, "No input received.")\
X(ERR_IO_INVALID_CMD,  104, "Invalid command.")\
X(ERR_IO_MULT_CMD,     105, "Only one command allowed at a time.")\
X(ERR_IO_DATA_LEN,     106, "Data must be less than " STRINGIFY(AES_DATA_LEN_MAX)" characters.")\
X(ERR_IO_REPORT_BUF,   107, "Output buffer overflow.")\
X(ERR_IO_DECRYPT,      108, "Could not decrypt.")\
X(ERR_IO_JSON_PARSE,   109, "JSON parse error.")\
X(ERR_IO_RESET,        110, "Too many failed access attempts. Device reset.")\
X(ERR_IO_LOCKED,       111, "Device locked. Erase device to access this command.")\
X(ERR_SEED_SD,         200, "Seed creation requires an SD card for automatic encrypted backup of the seed.")\
X(ERR_SEED_SD_NUM,     201, "Too many backup files. Please remove one from the SD card.")\
X(ERR_SEED_MEM,        202, "Could not allocate memory for seed.")\
X(ERR_SEED_SALT_LEN,   203, "Salt must be less than " STRINGIFY(SALT_LEN_MAX) " characters.")\
X(ERR_SEED_INVALID,    204, "Invalid seed.")\
X(ERR_KEY_MASTER,      250, "Master key not present.")\
X(ERR_KEY_CHILD,       251, "Could not generate key.")\
X(ERR_SIGN_ADDR_LEN,   300, "Incorrect address length. A 34 character address is expected.")\
X(ERR_SIGN_HASH_LEN,   301, "Incorrect hash length. A 32-byte hexadecimal value (64 characters) is expected.")\
X(ERR_SIGN_DESERIAL,   302, "Could not deserialize outputs or wrong change keypath.")\
X(ERR_SIGN_ECCLIB,     303, "Could not sign.")\
X(ERR_SD_CARD,         400, "Please insert SD card.")\
X(ERR_SD_MOUNT,        401, "Could not mount the SD card.")\
X(ERR_SD_OPEN_FILE,    402, "Could not open a file to write - it may already exist.")\
X(ERR_SD_OPEN_DIR,     403, "Could not open the directory.")\
X(ERR_SD_CORRUPT_FILE, 404, "Corrupted file.")\
X(ERR_SD_WRITE_FILE,   405, "Could not write the file.")\
X(ERR_SD_WRITE_LEN,    406, "Text to write is too large.")\
X(ERR_SD_READ_FILE,    407, "Could not read the file.")\
X(ERR_SD_ERASE,        408, "May not have erased all files (or no file present).")\
X(ERR_SD_NUM_FILES,    409, "Too many files to read. The list is truncated.")\
X(ERR_MEM_ATAES,       500, "Chip communication error.")\
X(ERR_MEM_FLASH,       501, "Could not read flash.")\
X(ERR_MEM_ENCRYPT,     502, "Could not encrypt.")\
X(WARN_RESET,          900, "attempts remain before the device is reset.")\
X(WARN_NO_MCU,         901, "Ignored for non-embedded testing.")\
X(FLAG_NUM,              0, 0)/* keep last */
```

#### Test coverage
- cmake option enables compilation with test coverage flags 
- increased test coverage in general
- use `utest.h` macros in `tests_api` (already used in `tests_unit`)(better readability and easier to update)


#### General house cleaning
- improve code consistency and efficiency
- fix white space
- use snprintf instead of sprintf or memcpy when possible
- use [X macros](http://www.drdobbs.com/the-new-c-x-macros/184401387) in `flags.h` `flags.c` 


