### PR TITLE
Use 'long touch' option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
     - cd $TRAVIS_BUILD_DIR
     - if astyle --style=stroustrup --indent-switches --indent-labels --pad-oper --pad-header --align-pointer=name --add-brackets --convert-tabs --max-code-length=90 --break-after-logical --suffix=none *.c *.h --recursive --exclude=astyle --exclude=src/yajl --exclude=src/secp256k1 --exclude=tests/windows/hidapi --dry-run -Q | grep "Formatted" ; then exit 1 ; fi;
     - gpg --import contrib/contributors_gpg_keys/*
-    - if git log --pretty="format:%H   %aN   %s   %G?" f0a012e224fedac87b0393a161d4af1473fea74a..HEAD^1 | (grep -v "${t} G$" || grep -v "${t} U$"); then exit 1 ; fi;
+    - if git log --pretty="format:%H   %aN   %s   %G?" f0a012e224fedac87b0393a161d4af1473fea74a..HEAD^1 | grep -v "${t} G$" | grep -v "${t} U$"; then exit 1 ; fi;
 
 script: 
     - mkdir build && cd build

--- a/src/commander.c
+++ b/src/commander.c
@@ -304,16 +304,10 @@ static void commander_process_reset(yajl_val json_node)
     }
 
     if (strncmp(value, attr_str(ATTR___ERASE__), strlens(attr_str(ATTR___ERASE__))) == 0) {
-        if (touch_button_press(0) == DBB_TOUCHED) {
-            delay_ms(100);
-            if (touch_button_press(0) == DBB_TOUCHED) {
-                delay_ms(100);
-                if (touch_button_press(0) == DBB_TOUCHED) {
-                    memory_erase();
-                    commander_clear_report();
-                    commander_fill_report(cmd_str(CMD_reset), attr_str(ATTR_success), DBB_OK);
-                }
-            }
+        if (touch_button_press(DBB_TOUCH_LONG) == DBB_TOUCHED) {
+            memory_erase();
+            commander_clear_report();
+            commander_fill_report(cmd_str(CMD_reset), attr_str(ATTR_success), DBB_OK);
         }
         return;
     }
@@ -1193,7 +1187,7 @@ static int commander_touch_button(int found_cmd, yajl_val json_node)
         int c = commander_echo_command(json_node);
         if (c == DBB_VERIFY_SAME) {
             int t;
-            t = touch_button_press(1);
+            t = touch_button_press(DBB_TOUCH_LONG);
             if (t != DBB_TOUCHED) {
                 // Clear previous signing information
                 // to force touch for next sign command.
@@ -1212,9 +1206,10 @@ static int commander_touch_button(int found_cmd, yajl_val json_node)
     memset(previous_command, 0, COMMANDER_REPORT_SIZE);
 
     if (found_cmd == CMD_seed && !memcmp(memory_master(NULL), MEM_PAGE_ERASE, 32)) {
+        // No touch required if not yet seeded
         return DBB_TOUCHED;
     } else if (found_cmd < CMD_REQUIRE_TOUCH) {
-        return (touch_button_press(0));
+        return (touch_button_press(DBB_TOUCH_LONG));
 
     } else {
         return DBB_TOUCHED;

--- a/src/flags.h
+++ b/src/flags.h
@@ -136,6 +136,8 @@ X(VERIFY_SAME,           0, 0)\
 X(VERIFY_DIFFERENT,      0, 0)\
 X(TOUCHED,               0, 0)\
 X(NOT_TOUCHED,           0, 0)\
+X(TOUCH_SHORT,           0, 0)\
+X(TOUCH_LONG,            0, 0)\
 X(KEY_PRESENT,           0, 0)\
 X(KEY_ABSENT,            0, 0)\
 X(RESET,                 0, 0)\

--- a/src/sham.c
+++ b/src/sham.c
@@ -89,9 +89,9 @@ uint8_t sd_erase(int cmd)
 }
 
 
-uint8_t touch_button_press(int long_touch)
+uint8_t touch_button_press(uint8_t touch_type)
 {
-    (void) long_touch;
+    (void) touch_type;
     commander_fill_report(cmd_str(CMD_touchbutton), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
     return DBB_TOUCHED;
 }

--- a/src/sham.h
+++ b/src/sham.h
@@ -38,7 +38,7 @@ uint8_t sd_write(const char *f, uint16_t f_len, const char *t, uint16_t t_len,
 char *sd_load(const char *f, uint16_t f_len, int cmd);
 uint8_t sd_list(int cmd);
 uint8_t sd_erase(int cmd);
-uint8_t touch_button_press(int long_touch);
+uint8_t touch_button_press(uint8_t touch_type);
 uint8_t flash_read_unique_id(uint32_t *serial, uint32_t len);
 
 

--- a/src/touch.h
+++ b/src/touch.h
@@ -48,7 +48,7 @@
 
 
 void touch_init(void);
-uint8_t touch_button_press(int long_touch);
+uint8_t touch_button_press(uint8_t touch_type);
 
 
 #endif

--- a/src/version.h
+++ b/src/version.h
@@ -28,6 +28,6 @@
 #ifndef VERSION_H
 #define VERSION_H
 
-const char *DIGITAL_BITBOX_VERSION = "v1.1-23-g5665777";
+const char *DIGITAL_BITBOX_VERSION = "v1.2.0-10-g11fe104";
 
 #endif


### PR DESCRIPTION
Use 'long touch' option for all commands requiring touch: `sign`, `seed`, `erase`, and `password`. 

This simplifies the user experience by having to know only one touch button protocol. It also prevents accidentally accepting a `seed` command, by bumping the dbb for example. New `seed` commands erase the old seed, which is a potential risk to lose funds.

Long touch was used for `sign` before: pressing the touch button for more than 3 seconds equals 'accept' while pressing for less than 3 seconds equals 'reject'. The alternative 'short touch' option is no longer used: a single touch equals 'accept' with a timeout after 3 seconds. (I think it is good to keep the short touch code for potential future dev.) Previously, `erase` required 3 short touches in a row.