### PR TITLE
use secp256k1_context_randomize() for secp library context init

### DIFF
--- a/src/ecc.c
+++ b/src/ecc.c
@@ -32,6 +32,7 @@
 #include "sha2.h"
 #include "flags.h"
 #include "utils.h"
+#include "random.h"
 #include "ecc.h"
 #ifndef ECC_USE_UECC_LIB
 #include "secp256k1/include/secp256k1.h"
@@ -48,6 +49,12 @@ void ecc_context_init(void)
 #else
     ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
 #endif
+
+    uint8_t random[32] = {0};
+    random_bytes(random, sizeof(random), 0);
+    if (secp256k1_context_randomize(ctx, random)) {
+        /* pass */
+    }
 }
 
 


### PR DESCRIPTION
Closes #73.

Passed testing onchip. However it required a change in the secp256k1 library: https://github.com/digitalbitbox/secp256k1/commit/52bc47defdf1ae96419034bc9fbd38183f5e3705

likely due to the target ARM architecture: http://stackoverflow.com/a/13284139