### PR TITLE
expand travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,14 +3,33 @@ sudo: false
 os:
     - osx
     - linux
-    
+
+env:
+    - ENV="-DBUILD_TESTS=ON -DUSE_UECC_LIB=ON"   TEST=yes
+    - ENV="-DBUILD_TESTS=ON -DUSE_UECC_LIB=OFF"  TEST=yes
+    - ENV="-DBUILD_TESTS=OFF -DUSE_UECC_LIB=ON"  TEST=no
+#    - ENV="-DBUILD_TESTS=OFF -DUSE_UECC_LIB=OFF" TEST=no # secp lib too big at the moment
+
 compiler:
     - clang
     - gcc
 
 matrix:
+    exclude:
+        # mcu build uses its own arm compiler, so reduce the matrix size
+        - compiler: gcc 
+          env: ENV="-DBUILD_TESTS=OFF -DUSE_UECC_LIB=ON"  TEST=no
+        # osx gcc compiler seems to default to clang, so skip gcc
+        - compiler: gcc
+          os: osx
     fast_finish:
         - true
+
+addons:
+  apt_packages:
+    - lib32bz2-1.0
+    - lib32ncurses5
+    - lib32z1
 
 install:
     - if [ $TRAVIS_OS_NAME == linux ]; then
@@ -19,6 +38,18 @@ install:
         export PATH=$PATH:$PWD/bin/;
       fi;
     - if [ $TRAVIS_OS_NAME == osx ]; then brew install gnupg; fi
+    - if [ "$TEST" = "no" ]; then
+      if [ $TRAVIS_OS_NAME == linux ]; then
+        wget https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q3-update/+download/gcc-arm-none-eabi-4_9-2015q3-20150921-linux.tar.bz2;
+        tar -xf gcc-arm-none-eabi-4_9-2015q3-20150921-linux.tar.bz2;
+        export PATH=$PWD/gcc-arm-none-eabi-4_9-2015q3/bin:$PATH;
+      fi;
+      if [ $TRAVIS_OS_NAME == osx ]; then
+        wget https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q3-update/+download/gcc-arm-none-eabi-4_9-2015q3-20150921-mac.tar.bz2;
+        tar -xf gcc-arm-none-eabi-4_9-2015q3-20150921-mac.tar.bz2;
+        export PATH=$PWD/gcc-arm-none-eabi-4_9-2015q3/bin:$PATH;
+      fi;
+      fi;
 
 before_script:
     - cd $TRAVIS_BUILD_DIR
@@ -28,7 +59,5 @@ before_script:
 
 script: 
     - mkdir build && cd build
-    - cmake .. -DCONTINUOUS_INTEGRATION=1 -DBUILD_COVERAGE=OFF && make
-    - make test
-    - bin/tests_api
-    - bin/tests_unit
+    - cmake .. $ENV -DCONTINUOUS_INTEGRATION=1 && make
+    - if [ "$TEST" = "yes" ]; then make test; fi

--- a/firmware.cmake
+++ b/firmware.cmake
@@ -12,13 +12,15 @@ set(CMAKE_LINKER "arm-none-eabi-ld" CACHE PATH "" FORCE)
 set(CMAKE_SIZE "arm-none-eabi-size")
 set(CMAKE_OBJCOPY "arm-none-eabi-objcopy")
 
-# search for programs in the build host directories
+# Search for programs in the build host directories
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 
-# for libraries and headers in the target directories
-#SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-#SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+# For libraries and headers in the target directories
+#set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+#set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 
-
-
+# Avoid known bug in linux giving: 
+#    arm-none-eabi-gcc: error: unrecognized command line option '-rdynamic'
+set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
+set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
 

--- a/src/ecc.c
+++ b/src/ecc.c
@@ -50,9 +50,9 @@ void ecc_context_init(void)
     ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN);
 #endif
 
-    uint8_t random[32] = {0};
-    random_bytes(random, sizeof(random), 0);
-    if (secp256k1_context_randomize(ctx, random)) {
+    uint8_t rndm[32] = {0};
+    random_bytes(rndm, sizeof(rndm), 0);
+    if (secp256k1_context_randomize(ctx, rndm)) {
         /* pass */
     }
 }


### PR DESCRIPTION
Expand travis testing using a matrix of environment variables, including a build of the firmware.
( To be rebased on top of #78 )
