### PR TITLE
add coveralls test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ addons:
     - valgrind
 
 install:
+    - pip install --user cpp-coveralls 
     - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
         tar xfv contrib/astyle_2.05.1_linux.tar.gz;
         cd astyle/build/gcc && make;
@@ -43,16 +44,16 @@ install:
         brew install gnupg;
       fi
     - if [ "$TEST" = "no" ]; then
-      if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
-        wget https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q3-update/+download/gcc-arm-none-eabi-4_9-2015q3-20150921-linux.tar.bz2;
-        tar -xf gcc-arm-none-eabi-4_9-2015q3-20150921-linux.tar.bz2;
-        export PATH=$PWD/gcc-arm-none-eabi-4_9-2015q3/bin:$PATH;
-      fi;
-      if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
-        wget https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q3-update/+download/gcc-arm-none-eabi-4_9-2015q3-20150921-mac.tar.bz2;
-        tar -xf gcc-arm-none-eabi-4_9-2015q3-20150921-mac.tar.bz2;
-        export PATH=$PWD/gcc-arm-none-eabi-4_9-2015q3/bin:$PATH;
-      fi;
+        if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
+          wget https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q3-update/+download/gcc-arm-none-eabi-4_9-2015q3-20150921-linux.tar.bz2;
+          tar -xf gcc-arm-none-eabi-4_9-2015q3-20150921-linux.tar.bz2;
+          export PATH=$PWD/gcc-arm-none-eabi-4_9-2015q3/bin:$PATH;
+        fi;
+        if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+          wget https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q3-update/+download/gcc-arm-none-eabi-4_9-2015q3-20150921-mac.tar.bz2;
+          tar -xf gcc-arm-none-eabi-4_9-2015q3-20150921-mac.tar.bz2;
+          export PATH=$PWD/gcc-arm-none-eabi-4_9-2015q3/bin:$PATH;
+        fi;
       fi;
 
 before_script:
@@ -71,3 +72,7 @@ script:
           valgrind --leak-check=full --error-exitcode=1 bin/tests_unit;
         fi;
       fi;
+
+      
+after_success:
+    - coveralls --verbose -i src -x c --exclude $TRAVIS_BUILD_DIR/src/secp256k1/src --exclude $TRAVIS_BUILD_DIR/src/yajl/src --exclude $TRAVIS_BUILD_DIR/build/src/CMakeFiles/bitbox.dir/yajl/src -r $TRAVIS_BUILD_DIR -b $TRAVIS_BUILD_DIR/build/src/CMakeFiles/bitbox.dir --gcov-options '\-lp'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Digital Bitbox Firmware
 ============
 
 [![Build Status](https://travis-ci.org/digitalbitbox/mcu.svg?branch=master)](https://travis-ci.org/digitalbitbox/mcu)
+[![Coverage Status](https://coveralls.io/repos/digitalbitbox/mcu/badge.svg?branch=master&service=github)](https://coveralls.io/github/digitalbitbox/mcu?branch=master)
 [![License](http://img.shields.io/:License-MIT-yellow.svg)](LICENSE)
 
 **MCU code for the [Digital Bitbox](https://digitalbitbox.com) hardware wallet.**

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,6 @@ set(DBB-FIRMWARE-SOURCES
         pbkdf2.c
         random.c
         ripemd160.c
-        uECC.c
         ecc.c
         secp256k1.c
         utils.c
@@ -27,6 +26,13 @@ set(DBB-FIRMWARE-SOURCES
         flags.c
         sha2.c
 )
+
+if(USE_UECC_LIB)
+    set(DBB-FIRMWARE-SOURCES
+        ${DBB-FIRMWARE-SOURCES}
+        uECC.c
+    )
+endif()
 
 set(DBB-HARDWARE-SOURCES
         ataes132.c

--- a/src/flags.c
+++ b/src/flags.c
@@ -44,10 +44,6 @@ const char *const FLAG_CODE[] = { FLAG_TABLE };
 const char *const FLAG_MSG[] = { FLAG_TABLE };
 #undef X
 
-#define X(a, b, c) #a,
-const char *const FLAG_ID[] = { FLAG_TABLE };
-#undef X
-
 const char *cmd_str(int cmd)
 {
     return CMD_STR[cmd];
@@ -70,10 +66,3 @@ const char *flag_msg(int flag)
 {
     return FLAG_MSG[flag];
 }
-
-
-const char *flag_id(int flag)
-{
-    return FLAG_ID[flag];
-}
-

--- a/src/flags.h
+++ b/src/flags.h
@@ -217,7 +217,6 @@ const char *cmd_str(int cmd);
 const char *attr_str(int attr);
 const char *flag_code(int flag);
 const char *flag_msg(int flag);
-const char *flag_id(int flag);
 
 
 #endif


### PR DESCRIPTION
fixes #82 
The external yajl and secp256k1 git submodules are excluded from coverage.