### PR TITLE
updates for ecdh 2FA pairing

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -650,10 +650,9 @@ static int commander_process_password(const char *message, int msg_len, PASSWORD
 }
 
 
-static int commander_process_ecdh(int cmd, uint8_t *pair_pubkey, uint8_t ledcode,
-                                  uint8_t *out_pubkey, uint8_t *ecdh_secret)
+static int commander_process_ecdh(int cmd, uint8_t *pair_pubkey, uint8_t *out_pubkey)
 {
-    uint8_t rand_privkey[32], rand_led[4], ret, i;
+    uint8_t rand_privkey[32], ecdh_secret[32], rand_led, ret, i = 0;
 
     if (random_bytes(rand_privkey, sizeof(rand_privkey), 0) == DBB_ERROR) {
         commander_fill_report(cmd_str(cmd), NULL, DBB_ERR_MEM_ATAES);
@@ -665,24 +664,26 @@ static int commander_process_ecdh(int cmd, uint8_t *pair_pubkey, uint8_t ledcode
         return DBB_ERROR;
     }
 
-    // Second channel LED blink code to avoid MITM
-    if (ledcode) {
-        if (random_bytes(rand_led, sizeof(rand_led), 0) == DBB_ERROR) {
+    // Use a 'second channel' LED blink code to avoid MITM
+    while (touch_button_press(DBB_TOUCH_SHORT) == DBB_TOUCHED) {
+        if (random_bytes(&rand_led, sizeof(rand_led), 0) == DBB_ERROR) {
             commander_fill_report(cmd_str(cmd), NULL, DBB_ERR_MEM_ATAES);
             return DBB_ERROR;
         }
 
-        for (i = 0; i < sizeof(rand_led); i++) {
-            rand_led[i] %= LED_MAX_CODE_BLINKS;
-            rand_led[i]++;
-        }
+        rand_led %= LED_MAX_CODE_BLINKS;
+        rand_led++; // min 1 blink
+        led_code(&rand_led, sizeof(rand_led));
 
-        led_code(rand_led, sizeof(rand_led));
-
-        // Xor with the ECDH secret
+        // Xor ECDH secret
         for (i = 0; i < 32; i++) {
-            ecdh_secret[i] ^= rand_led[i % sizeof(rand_led)];
+            ecdh_secret[i] ^= rand_led;
         }
+    }
+
+    if (i == 0) {
+        // While loop not entered
+        return DBB_ERROR;
     }
 
     // Save to eeprom
@@ -695,6 +696,7 @@ static int commander_process_ecdh(int cmd, uint8_t *pair_pubkey, uint8_t ledcode
 
     ecc_get_public_key33(rand_privkey, out_pubkey);
     memset(rand_privkey, 0, sizeof(rand_privkey));
+    memset(ecdh_secret, 0, sizeof(ecdh_secret));
     utils_clear_buffers();
     return DBB_OK;
 }
@@ -742,6 +744,11 @@ static void commander_process_verifypass(yajl_val json_node)
 
     if (strlens(value)) {
         if (strcmp(value, attr_str(ATTR_create)) == 0) {
+
+            if (touch_button_press(DBB_TOUCH_LONG) != DBB_TOUCHED) {
+                return;
+            }
+
             if (random_bytes(number, sizeof(number), 1) == DBB_ERROR) {
                 commander_fill_report(cmd_str(CMD_verifypass), NULL, DBB_ERR_MEM_ATAES);
                 return;
@@ -763,15 +770,14 @@ static void commander_process_verifypass(yajl_val json_node)
             return;
         }
 
-        uint8_t out_pubkey[33], ecdh_secret[32];
-        if (commander_process_ecdh(CMD_verifypass, utils_hex_to_uint8(pair_pubkey), 1, out_pubkey,
-                                   ecdh_secret) == DBB_OK) {
+        uint8_t out_pubkey[33];
+        if (commander_process_ecdh(CMD_verifypass, utils_hex_to_uint8(pair_pubkey),
+                                   out_pubkey) == DBB_OK) {
             char msg[256];
             snprintf(msg, sizeof(msg), "{\"%s\":\"%s\"}", cmd_str(CMD_ecdh),
                      utils_uint8_to_hex(out_pubkey, sizeof(out_pubkey)));
             commander_fill_report(cmd_str(CMD_verifypass), msg, DBB_JSON_ARRAY);
         }
-        memset(ecdh_secret, 0, sizeof(ecdh_secret));
         return;
     }
 

--- a/src/commander.h
+++ b/src/commander.h
@@ -43,6 +43,7 @@
 #define COMMANDER_ARRAY_ELEMENT_MAX 1024
 #define COMMANDER_MAX_ATTEMPTS      15// max attempts before device reset
 #define VERIFYPASS_FILENAME         "verification.txt"
+#define VERIFYPASS_CRYPT_TEST       "Digital Bitbox 2FA"
 #define AUTOBACKUP_FILENAME         "autobackup_"
 #define AUTOBACKUP_ENCRYPT          "yes"
 #define AUTOBACKUP_NUM              10

--- a/src/flags.h
+++ b/src/flags.h
@@ -45,12 +45,12 @@
 X(seed)           \
 X(sign)           \
 X(password)       \
-X(verifypass)     \
 /* placeholder  */\
 /* do not move  */\
 X(REQUIRE_TOUCH)  \
 /* parent keys  */\
 /*  w/o touch   */\
+X(verifypass)     \
 X(led)            \
 X(xpub)           \
 X(name)           \
@@ -139,8 +139,10 @@ X(VERIFY_SAME,           0, 0)\
 X(VERIFY_DIFFERENT,      0, 0)\
 X(TOUCHED,               0, 0)\
 X(NOT_TOUCHED,           0, 0)\
+X(TOUCHED_ABORT,         0, 0)\
 X(TOUCH_SHORT,           0, 0)\
 X(TOUCH_LONG,            0, 0)\
+X(TOUCH_TIMEOUT,         0, 0)\
 X(KEY_PRESENT,           0, 0)\
 X(KEY_ABSENT,            0, 0)\
 X(RESET,                 0, 0)\

--- a/src/led.c
+++ b/src/led.c
@@ -78,7 +78,7 @@ void led_toggle(void)
 void led_code(uint8_t *code, uint8_t len)
 {
     uint8_t i, j;
-    delay_ms(1000);
+    delay_ms(2000);
     for (i = 0; i < len; i++) {
         for (j = 0; j < code[i]; j++) {
             led_toggle();
@@ -86,6 +86,6 @@ void led_code(uint8_t *code, uint8_t len)
             led_toggle();
             delay_ms(300);
         }
-        delay_ms(1000);
+        delay_ms(2000);
     }
 }

--- a/src/sham.c
+++ b/src/sham.c
@@ -89,9 +89,19 @@ uint8_t sd_erase(int cmd)
 }
 
 
+uint8_t touch_short_count = 0;
+
 uint8_t touch_button_press(uint8_t touch_type)
 {
-    (void) touch_type;
+    if (touch_type == DBB_TOUCH_SHORT) {
+        // Simulate touch sequence for ecdh led blink coding
+        if (!touch_short_count) {
+            touch_short_count++;
+        } else {
+            touch_short_count = 0;
+            return DBB_TOUCHED_ABORT;
+        }
+    }
     commander_fill_report(cmd_str(CMD_touchbutton), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
     return DBB_TOUCHED;
 }

--- a/tests/utest.h
+++ b/tests/utest.h
@@ -152,6 +152,18 @@
   return; }; \
  } while(0); }
 
+#define u_assert_mem_not_eq(R,E,L) {\
+ const void * r_ = (R); \
+ const void * e_ = (E); \
+ size_t l_ = (L); \
+ do { if (!memcmp(r_,e_,l_)) { \
+  printf("FAILED - %s() - Line %d\n", __func__, __LINE__);\
+  printf("\tExpect: \t%s\n", utils_uint8_to_hex(e_,l_));\
+  printf("\tReceive:\t%s\n", utils_uint8_to_hex(r_,l_));\
+  U_TESTS_FAIL++;\
+  return; }; \
+ } while(0); }
+
 extern int U_TESTS_RUN;
 extern int U_TESTS_FAIL;
 


### PR DESCRIPTION
1
Updates the touch sequence used for #68 (ECDH 2FA key pairing).

As before, the LED blinks 1, 2, 3, or 4 times. But now, the next set of blinks does not occur until after the user 'short' touches the touch button. This allows time for the user to enter the number of blinks into the 2FA device. The procedure can be repeated any number of times, and must occur at least one time. A 'long' touch exits the procedure. 

---

2
Adds unit tests.

---

3
API now returns sample encrypted text to verify that pairing was done correctly:

**send** (enter the shared public key from the 2FA device)
```
{ "verifypass": { 
    "ecdh": "028d3bce812ac027fdea0e4ad98b2549a90bb9aa996396eec6bb1a8ed56e6976b8"
    }
}
```

**reply** (returns the shared public key from DBB)
```
{"verifypass": {
    "ecdh": "033794bd30bb64fd44d6e832557f120b49c4a6d9981235c18fc84597944d252720",
    "ciphertext": "6UJ3BBDkHgut2+psgvgoKeYuEKCG7C+NhT/Gs91tGas40pSGuQtBXD7ouLdJ6JaW"
  }
}
```

The sample ciphertext is set as:
```
#define VERIFYPASS_CRYPT_TEST       "Digital Bitbox 2FA"
```