### PR TITLE
ECDH updates

### DIFF
--- a/src/led.c
+++ b/src/led.c
@@ -78,7 +78,7 @@ void led_toggle(void)
 void led_code(uint8_t *code, uint8_t len)
 {
     uint8_t i, j;
-    delay_ms(2000);
+    delay_ms(1500);
     for (i = 0; i < len; i++) {
         for (j = 0; j < code[i]; j++) {
             led_toggle();
@@ -86,6 +86,6 @@ void led_code(uint8_t *code, uint8_t len)
             led_toggle();
             delay_ms(300);
         }
-        delay_ms(2000);
+        delay_ms(1500);
     }
 }

--- a/src/secp256k1.c
+++ b/src/secp256k1.c
@@ -34,10 +34,12 @@
 #pragma GCC diagnostic ignored "-Winline"
 #pragma GCC diagnostic ignored "-Wcast-qual"
 #pragma GCC diagnostic ignored "-Wuninitialized"
+#pragma GCC diagnostic ignored "-Wunused-variable"
 #endif
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunused-variable"
 #endif
 
 

--- a/src/uECC.c
+++ b/src/uECC.c
@@ -866,11 +866,15 @@ static bitcount_t smax(bitcount_t a, bitcount_t b)
 }
 
 
+
+#include <stdio.h>
+#include "utils.h"
+
 /* Compute a shared secret given your secret key and someone's public key.
    Returns 0 on success. */
 int uECC_shared_secret(const uint8_t public_key[uECC_BYTES * 2],
                        const uint8_t private_key[uECC_BYTES],
-                       uint8_t secret[uECC_BYTES])
+                       uint8_t secret_compressed[uECC_BYTES + 1])
 {
     EccPoint public;
     EccPoint product;
@@ -882,7 +886,7 @@ int uECC_shared_secret(const uint8_t public_key[uECC_BYTES * 2],
     uECC_word_t tries;
     uECC_word_t carry;
     uint8_t secret_point[uECC_BYTES * 2];
-    uint8_t secret_compressed[uECC_BYTES + 1];
+    //uint8_t secret_compressed[uECC_BYTES + 1];
 
     // Try to get a random initial Z value to improve protection against side-channel
     // attacks. If the RNG fails every time (eg it was not defined), we continue so that
@@ -910,8 +914,11 @@ int uECC_shared_secret(const uint8_t public_key[uECC_BYTES * 2],
     vli_nativeToBytes(secret_point + uECC_BYTES, product.y);
     uECC_compress(secret_point, secret_compressed);
 
-    sha256_Raw(secret_compressed, uECC_BYTES + 1, secret);
-
+    // NodeJS Crypto ECDH (2FA smartphone pairing) uses the x coordinate
+    // intead of the compressed key as the shared secret. So do not SHA
+    // hash here, return the compressed key, and decide how to hash in the
+    // calling code.
+    //sha256_Raw(secret_compressed, uECC_BYTES + 1, secret);
     return EccPoint_isZero(&product);
 }
 

--- a/tests/tests_secp256k1.c
+++ b/tests/tests_secp256k1.c
@@ -32,11 +32,13 @@
 #pragma GCC diagnostic ignored "-Wcast-qual"
 #pragma GCC diagnostic ignored "-Wshadow"
 #pragma GCC diagnostic ignored "-Wuninitialized"
+#pragma GCC diagnostic ignored "-Wunused-variable"
 #endif
 #ifdef __clang__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wmissing-prototypes"
 #pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunused-variable"
 #endif
 
 


### PR DESCRIPTION
The smartphone 2FA app uses javascript Crypto.js library, which unfortunately does not produce the same ECDH shared secret as uECC or libsecp256k1. The Crypto.js shared secret is an unhashed point x coordinate. uECC and libsecp256k1 give single sha256 hash of the compressed pubkey (i.e. x coordinate with an extra 0x02 or 0x03 byte prefixed). Therefore, this pull request removes the sha256 hash and code calling ECDH (ecc.c) removes the byte to get ECDH working with the smartphone.

(Also up to date with current secp256k1.)
