### PR TITLE
update blink UI

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -197,6 +197,7 @@ void commander_fill_report(const char *cmd, const char *msg, int flag)
 
     if ((strlens(json_report) + 1) >= COMMANDER_REPORT_SIZE) {
         if (!REPORT_BUF_OVERFLOW) {
+            commander_clear_report();
             snprintf(json_report, COMMANDER_REPORT_SIZE,
                      "{\"%s\":{\"message\":\"%s\", \"code\":%s, \"command\":\"%s\"}}", attr_str(ATTR_error),
                      flag_msg(DBB_ERR_IO_REPORT_BUF), flag_code(DBB_ERR_IO_REPORT_BUF), cmd);
@@ -619,7 +620,7 @@ static int commander_process_ecdh(int cmd, const uint8_t *pair_pubkey,
     }
 
     // Use a 'second channel' LED blink code to avoid MITM
-    while (touch_button_press(DBB_TOUCH_SHORT) == DBB_TOUCHED) {
+    while (touch_button_press(DBB_TOUCH_REJECT_TIMEOUT) == DBB_ERR_TOUCH_TIMEOUT) {
         if (random_bytes(&rand_led, sizeof(rand_led), 0) == DBB_ERROR) {
             commander_fill_report(cmd_str(cmd), NULL, DBB_ERR_MEM_ATAES);
             return DBB_ERROR;

--- a/src/flags.h
+++ b/src/flags.h
@@ -159,9 +159,10 @@ X(VERIFY_DIFFERENT,      0, 0)\
 X(TOUCHED,               0, 0)\
 X(NOT_TOUCHED,           0, 0)\
 X(TOUCHED_ABORT,         0, 0)\
-X(TOUCH_SHORT,           0, 0)\
-X(TOUCH_LONG,            0, 0)\
-X(TOUCH_TIMEOUT,         0, 0)\
+X(TOUCH_SHORT,           0, 0) /* brief touch accept; hold 3s reject       */\
+X(TOUCH_LONG,            0, 0) /* brief touch reject; hold 3s accept (led) */\
+X(TOUCH_TIMEOUT,         0, 0) /* touch accept; 3s timeout reject          */\
+X(TOUCH_REJECT_TIMEOUT,  0, 0) /* touch reject; 3s timeout accept          */\
 X(KEY_PRESENT,           0, 0)\
 X(KEY_ABSENT,            0, 0)\
 X(RESET,                 0, 0)\

--- a/src/led.c
+++ b/src/led.c
@@ -78,7 +78,7 @@ void led_toggle(void)
 void led_code(uint8_t *code, uint8_t len)
 {
     uint8_t i, j;
-    delay_ms(1500);
+    delay_ms(500);
     for (i = 0; i < len; i++) {
         for (j = 0; j < code[i]; j++) {
             led_toggle();
@@ -86,6 +86,6 @@ void led_code(uint8_t *code, uint8_t len)
             led_toggle();
             delay_ms(300);
         }
-        delay_ms(1500);
+        delay_ms(500);
     }
 }

--- a/src/sham.c
+++ b/src/sham.c
@@ -93,13 +93,14 @@ uint8_t touch_short_count = 0;
 
 uint8_t touch_button_press(uint8_t touch_type)
 {
-    if (touch_type == DBB_TOUCH_SHORT) {
+    if (touch_type == DBB_TOUCH_REJECT_TIMEOUT) {
         // Simulate touch sequence for ecdh led blink coding
         if (!touch_short_count) {
             touch_short_count++;
+            return DBB_ERR_TOUCH_TIMEOUT;
         } else {
             touch_short_count = 0;
-            return DBB_TOUCHED_ABORT;
+            return DBB_ERR_TOUCH_ABORT;
         }
     }
     commander_fill_report(cmd_str(CMD_touchbutton), flag_msg(DBB_WARN_NO_MCU), DBB_OK);


### PR DESCRIPTION
Don't require user touch to continue to next blink sequence. A short touch in between blink sequences exits.