### PR TITLE
indicate presence of sd card for device:info command

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -815,6 +815,7 @@ static void commander_process_device(yajl_val json_node)
         char id[65] = {0};
         char lock[6] = {0};
         char seeded[6] = {0};
+        char sdcard[6] = {0};
         uint32_t serial[4] = {0};
 
         flash_read_unique_id(serial, 4);
@@ -832,14 +833,21 @@ static void commander_process_device(yajl_val json_node)
             strcpy(seeded, attr_str(ATTR_false));
         }
 
+        if (sd_present() == DBB_OK) {
+            strcpy(sdcard, attr_str(ATTR_true));
+        } else {
+            strcpy(sdcard, attr_str(ATTR_false));
+        }
+
         snprintf(msg, sizeof(msg),
-                 "{\"%s\":\"%s\", \"%s\":\"%s\", \"%s\":\"%s\", \"%s\":\"%s\", \"%s\":%s, \"%s\":%s}",
+                 "{\"%s\":\"%s\", \"%s\":\"%s\", \"%s\":\"%s\", \"%s\":\"%s\", \"%s\":%s, \"%s\":%s, \"%s\":%s}",
                  attr_str(ATTR_serial), utils_uint8_to_hex((uint8_t *)serial, sizeof(serial)),
                  attr_str(ATTR_version), DIGITAL_BITBOX_VERSION,
                  attr_str(ATTR_name), (char *)memory_name(""),
                  attr_str(ATTR_id), id,
                  attr_str(ATTR_seeded), seeded,
-                 attr_str(ATTR_lock), lock);
+                 attr_str(ATTR_lock), lock,
+                 attr_str(ATTR_sdcard), sdcard);
 
         commander_fill_report(cmd_str(CMD_device), msg, DBB_JSON_ARRAY);
         return;

--- a/src/flags.h
+++ b/src/flags.h
@@ -123,6 +123,7 @@ X(aborted)        \
 X(yes)            \
 X(meta)           \
 X(list)           \
+X(sdcard)         \
 X(lock)           \
 X(unlock)         \
 X(decrypt)        \

--- a/src/sd.c
+++ b/src/sd.c
@@ -256,6 +256,25 @@ err:
 }
 
 
+uint8_t sd_present(void)
+{
+    sd_mmc_init();
+    sd_listing_pos = 0;
+
+    if (CTRL_FAIL == sd_mmc_test_unit_ready(0)) {
+        return DBB_ERROR;
+    }
+
+    memset(&fs, 0, sizeof(FATFS));
+    if (FR_INVALID_DRIVE == f_mount(LUN_ID_SD_MMC_0_MEM, &fs)) {
+        return DBB_ERROR;
+    }
+    f_mount(LUN_ID_SD_MMC_0_MEM, NULL);
+
+    return DBB_OK;
+}
+
+
 static uint8_t delete_files(char *path)
 {
     int failed = 0;

--- a/src/sd.h
+++ b/src/sd.h
@@ -29,6 +29,7 @@
 #define _SD_H_
 
 uint8_t sd_list(int cmd);
+uint8_t sd_present(void);
 uint8_t sd_erase(int cmd);
 char *sd_load(const char *f, uint16_t f_len, int cmd);
 uint8_t sd_write(const char *f, uint16_t f_len, const char *text, uint16_t t_len,

--- a/src/sham.c
+++ b/src/sham.c
@@ -79,6 +79,13 @@ uint8_t sd_list(int cmd)
 }
 
 
+uint8_t sd_present(void)
+{
+    commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
+    return DBB_OK;
+}
+
+
 uint8_t sd_erase(int cmd)
 {
     (void) cmd;

--- a/src/sham.h
+++ b/src/sham.h
@@ -37,6 +37,7 @@ uint8_t sd_write(const char *f, uint16_t f_len, const char *t, uint16_t t_len,
                  uint8_t replace, int cmd);
 char *sd_load(const char *f, uint16_t f_len, int cmd);
 uint8_t sd_list(int cmd);
+uint8_t sd_present(void);
 uint8_t sd_erase(int cmd);
 uint8_t touch_button_press(uint8_t touch_type);
 uint8_t flash_read_unique_id(uint32_t *serial, uint32_t len);

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -390,6 +390,7 @@ static void tests_device(void)
 
     api_format_send_cmd(cmd_str(CMD_device), attr_str(ATTR_info), PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+    u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_sdcard));
     u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_serial));
     u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_version));
     u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_name));
@@ -406,6 +407,7 @@ static void tests_device(void)
 
     api_format_send_cmd(cmd_str(CMD_device), attr_str(ATTR_info), PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+    u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_sdcard));
     u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_serial));
     u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_version));
     u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_name));


### PR DESCRIPTION
The extra field returned is:
```
"sdcard": true
```
or
```
"sdcard": false
```