### PR TITLE
signing checkpub: use pubkey instead of address

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -1161,19 +1161,19 @@ static int commander_echo_command(yajl_val json_node)
         memset(json_array, 0, COMMANDER_ARRAY_MAX);
         for (size_t i = 0; i < check->u.array.len; i++) {
             const char *keypath_path[] = { cmd_str(CMD_keypath), NULL };
-            const char *address_path[] = { cmd_str(CMD_address), NULL };
+            const char *pubkey_path[] = { cmd_str(CMD_pubkey), NULL };
 
             yajl_val obj = check->u.array.values[i];
             const char *keypath = YAJL_GET_STRING(yajl_tree_get(obj, keypath_path, yajl_t_string));
-            const char *address = YAJL_GET_STRING(yajl_tree_get(obj, address_path, yajl_t_string));
+            const char *pubkey = YAJL_GET_STRING(yajl_tree_get(obj, pubkey_path, yajl_t_string));
 
-            if (!address || !keypath) {
+            if (!pubkey || !keypath) {
                 commander_clear_report();
                 commander_fill_report(cmd_str(CMD_sign), NULL, DBB_ERR_IO_INVALID_CMD);
                 return DBB_ERROR;
             }
 
-            ret = wallet_check_pubkey(address, keypath);
+            ret = wallet_check_pubkey(pubkey, keypath);
             const char *status;
             if (ret == DBB_KEY_PRESENT) {
                 status = attr_str(ATTR_true);
@@ -1183,8 +1183,8 @@ static int commander_echo_command(yajl_val json_node)
                 return DBB_ERROR;
             }
 
-            const char *key[] = {cmd_str(CMD_address), cmd_str(CMD_present), 0};
-            const char *value[] = {address, status, 0};
+            const char *key[] = {cmd_str(CMD_pubkey), cmd_str(CMD_present), 0};
+            const char *value[] = {pubkey, status, 0};
             int t[] = {DBB_JSON_STRING, DBB_JSON_BOOL, DBB_JSON_NONE};
             commander_fill_json_array(key, value, t, CMD_checkpub);
         }

--- a/src/flags.h
+++ b/src/flags.h
@@ -92,7 +92,6 @@ X(pubkey)         \
 X(checkpub)       \
 X(filename)       \
 X(keypath)        \
-X(address)        \
 X(present)        \
 X(decrypt)        \
 X(encrypt)        \
@@ -200,7 +199,7 @@ X(ERR_KEY_MASTER,      250, "Master key not present.")\
 X(ERR_KEY_CHILD,       251, "Could not generate key.")\
 X(ERR_KEY_ECDH,        252, "Could not generate ECDH secret.")\
 X(ERR_KEY_ECDH_LEN,    253, "Incorrect serialized pubkey length. A 33-byte hexadecimal value (66 characters) is expected.")\
-X(ERR_SIGN_ADDR_LEN,   300, "Incorrect address length. A 34 character address is expected.")\
+X(ERR_SIGN_PUBKEY_LEN, 300, "Incorrect pubkey length. A 33-byte hexadecimal value (66 characters) is expected.")\
 X(ERR_SIGN_HASH_LEN,   301, "Incorrect hash length. A 32-byte hexadecimal value (64 characters) is expected.")\
 X(ERR_SIGN_DESERIAL,   302, "Could not deserialize outputs or wrong change keypath.")\
 X(ERR_SIGN_ECCLIB,     303, "Could not sign.")\

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -224,15 +224,14 @@ void wallet_report_id(char *id)
 }
 
 
-int wallet_check_pubkey(const char *address, const char *keypath)
+int wallet_check_pubkey(const char *pubkey, const char *keypath)
 {
     uint8_t pub_key[33];
-    char addr[36];
     HDNode node;
 
-    if (strlens(address) != 34) {
+    if (strlens(pubkey) != 66) {
         commander_clear_report();
-        commander_fill_report(cmd_str(CMD_checkpub), NULL, DBB_ERR_SIGN_ADDR_LEN);
+        commander_fill_report(cmd_str(CMD_checkpub), NULL, DBB_ERR_SIGN_PUBKEY_LEN);
         goto err;
     }
 
@@ -250,10 +249,9 @@ int wallet_check_pubkey(const char *address, const char *keypath)
     }
 
     ecc_get_public_key33(node.private_key, pub_key);
-    wallet_get_address(pub_key, 0, addr, sizeof(addr));
 
     memset(&node, 0, sizeof(HDNode));
-    if (strncmp(address, addr, 36)) {
+    if (strncmp(pubkey, utils_uint8_to_hex(pub_key, 33), 66)) {
         return DBB_KEY_ABSENT;
     } else {
         return DBB_KEY_PRESENT;

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -38,7 +38,7 @@ int wallet_split_seed(char **seed_words, const char *message);
 int wallet_master_from_xpriv(char *src);
 int wallet_seeded(void);
 int wallet_generate_master(void);
-int wallet_check_pubkey(const char *pubkeyhash, const char *keypath);
+int wallet_check_pubkey(const char *pubkey, const char *keypath);
 int wallet_sign(const char *message, const char *keypath);
 void wallet_report_xpriv(const char *keypath, char *xpub);
 void wallet_report_xpub(const char *keypath, char *xpub);

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -692,9 +692,11 @@ static void tests_sign(void)
         "{\"meta\":\"_meta_data_\", \"data\": [{\"hash\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\", \"keypath\":\"m/\"},{\"hash\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\", \"keypath\":\"m/\"}, {\"hash\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\", \"keypath\":\"m/\"}, {\"hash\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\", \"keypath\":\"m/\"}, {\"hash\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\", \"keypath\":\"m/\"}, {\"hash\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\", \"keypath\":\"m/\"}, {\"hash\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\", \"keypath\":\"m/\"}, {\"hash\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\", \"keypath\":\"m/\"}, {\"hash\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\", \"keypath\":\"m/\"}, {\"hash\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\", \"keypath\":\"m/\"}]}";
 
     char checkpub[] =
-        "{\"meta\":\"<<meta data here>>\", \"data\": [{\"hash\":\"c6fa4c236f59020ec8ffde22f85a78e7f256e94cd975eb5199a4a5cc73e26e4a\", \"keypath\":\"m/44p\"},{\"hash\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\", \"keypath\":\"m/44p\"}], \"checkpub\":[{\"address\":\"0000000000000000000000000000000000\", \"keypath\":\"m/44p/0p/0p/1/8\"},{\"address\":\"1Q5pR8cZPtqyQf3xCVo25n9UDaiTWJZ4DC\", \"keypath\":\"m/44p/0p/0p/1/8\"}]}";
-    char check_1[] = "\"address\":\"0000000000000000000000000000000000\", \"present\":false";
-    char check_2[] = "\"address\":\"1Q5pR8cZPtqyQf3xCVo25n9UDaiTWJZ4DC\", \"present\":true";
+        "{\"meta\":\"<<meta data here>>\", \"data\": [{\"hash\":\"c6fa4c236f59020ec8ffde22f85a78e7f256e94cd975eb5199a4a5cc73e26e4a\", \"keypath\":\"m/44p\"},{\"hash\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\", \"keypath\":\"m/44p\"}], \"checkpub\":[{\"pubkey\":\"000000000000000000000000000000000000000000000000000000000000000000\", \"keypath\":\"m/44p/0p/0p/1/8\"},{\"pubkey\":\"032ab901fe42a05e970e6d5c701b4d7a6db33b0fa7daaaa709ebe755daf9dfe0ec\", \"keypath\":\"m/44p/0p/0p/1/8\"}]}";
+    char check_1[] =
+        "\"pubkey\":\"000000000000000000000000000000000000000000000000000000000000000000\", \"present\":false";
+    char check_2[] =
+        "\"pubkey\":\"032ab901fe42a05e970e6d5c701b4d7a6db33b0fa7daaaa709ebe755daf9dfe0ec\", \"present\":true";
     char check_sig_1[] =
         "72b2aa04281c7c2d79cb6e08168865fcd492d4d2d36acb3e46a185368c9ee00c1cbae958a8092a3689088d05ec5c0f58db65612f7bf4b34b0a9b3a34af9ad8be";
     char check_sig_2[] =
@@ -703,10 +705,10 @@ static void tests_sign(void)
         "02793907771bab33d3fa7e4d7ee7c355067a623265926c46fc433a83c11dceb29e";
 
     char checkpub_wrong_addr_len[] =
-        "{\"meta\":\"<<meta data here>>\", \"data\": [{\"hash\":\"c6fa4c236f59020ec8ffde22f85a78e7f256e94cd975eb5199a4a5cc73e26e4a\", \"keypath\":\"m/44p\"},{\"hash\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\", \"keypath\":\"m/44p\"}], \"checkpub\":[{\"address\":\"00\", \"keypath\":\"m/44p/0p/0p/1/8\"},{\"address\":\"1Q5pR8cZPtqyQf3xCVo25n9UDaiTWJZ4DC\", \"keypath\":\"m/44p/0p/0p/1/8\"}]}";
+        "{\"meta\":\"<<meta data here>>\", \"data\": [{\"hash\":\"c6fa4c236f59020ec8ffde22f85a78e7f256e94cd975eb5199a4a5cc73e26e4a\", \"keypath\":\"m/44p\"},{\"hash\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\", \"keypath\":\"m/44p\"}], \"checkpub\":[{\"pubkey\":\"00\", \"keypath\":\"m/44p/0p/0p/1/8\"},{\"pubkey\":\"032ab901fe42a05e970e6d5c701b4d7a6db33b0fa7daaaa709ebe755daf9dfe0ec\", \"keypath\":\"m/44p/0p/0p/1/8\"}]}";
 
     char checkpub_missing_parameter[] =
-        "{\"meta\":\"<<meta data here>>\", \"data\": [{\"hash\":\"c6fa4c236f59020ec8ffde22f85a78e7f256e94cd975eb5199a4a5cc73e26e4a\", \"keypath\":\"m/44p\"},{\"hash\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\", \"keypath\":\"m/44p\"}], \"checkpub\":[{\"address\":\"1Q5pR8cZPtqyQf3xCVo25n9UDaiTWJZ4DC\"}]}";
+        "{\"meta\":\"<<meta data here>>\", \"data\": [{\"hash\":\"c6fa4c236f59020ec8ffde22f85a78e7f256e94cd975eb5199a4a5cc73e26e4a\", \"keypath\":\"m/44p\"},{\"hash\":\"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\", \"keypath\":\"m/44p\"}], \"checkpub\":[{\"pubkey\":\"032ab901fe42a05e970e6d5c701b4d7a6db33b0fa7daaaa709ebe755daf9dfe0ec\"}]}";
 
 
     api_reset_device();
@@ -812,7 +814,7 @@ static void tests_sign(void)
     u_assert_str_has(utils_read_decrypted_report(), check_pubkey);
 
     api_format_send_cmd(cmd_str(CMD_sign), checkpub_wrong_addr_len, PASSWORD_STAND);
-    u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_SIGN_ADDR_LEN));
+    u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_SIGN_PUBKEY_LEN));
 
 
     // lock to get 2FA PINs


### PR DESCRIPTION
Fixes #103.
(Reference #43.)

Use a compressed pubkey instead of the address when checking if a pubkey is part of the wallet (e.g. for verifying output change addresses in transactions).

**send to dbb**
```
{ 
  "sign": 
  {
    "meta": "<<meta data here>>", 
    "data": [
        {"hash":"c6fa4c236f59020ec8ffde22f85a78e7f256e94cd975eb5199a4a5cc73e26e4a", "keypath":"m/44p"},
        {"hash":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "keypath":"m/44p"}
    ], 
    "checkpub":[
        {"pubkey":"000000000000000000000000000000000000000000000000000000000000000000", "keypath":"m/44p/0p/0p/1/8"},
        {"pubkey":"032ab901fe42a05e970e6d5c701b4d7a6db33b0fa7daaaa709ebe755daf9dfe0ec", "keypath":"m/44p/0p/0p/1/8"}
    ]
  }
}
```

**echo reply**
```
{ 
  "sign": 
  {
    "meta": "<<meta data here>>", 
    "data": [
        { "hash":"c6fa4c236f59020ec8ffde22f85a78e7f256e94cd975eb5199a4a5cc73e26e4a", "keypath":"m/44p"},
        { "hash":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "keypath":"m/44p"}
    ], 
    "checkpub": [
        { "pubkey":"000000000000000000000000000000000000000000000000000000000000000000", "present":false},
        { "pubkey":"032ab901fe42a05e970e6d5c701b4d7a6db33b0fa7daaaa709ebe755daf9dfe0ec", "present":true}
    ]
  }
}
```