### PR TITLE
return bootloader lock status with device:info command

### DIFF
--- a/src/flags.h
+++ b/src/flags.h
@@ -124,6 +124,7 @@ X(meta)           \
 X(list)           \
 X(sdcard)         \
 X(lock)           \
+X(bootlock)       \
 X(unlock)         \
 X(decrypt)        \
 X(encrypt)        \

--- a/src/sham.c
+++ b/src/sham.c
@@ -120,3 +120,10 @@ uint8_t flash_read_unique_id(uint32_t *serial, uint32_t len)
     memset(serial, 1, sizeof(uint32_t) * len);
     return 0; // success
 }
+
+
+uint8_t flash_read_user_signature(uint32_t *sig, uint32_t len)
+{
+    memset(sig, 0, sizeof(uint32_t) * len);
+    return 0;
+}

--- a/src/sham.h
+++ b/src/sham.h
@@ -41,6 +41,7 @@ uint8_t sd_present(void);
 uint8_t sd_erase(int cmd);
 uint8_t touch_button_press(uint8_t touch_type);
 uint8_t flash_read_unique_id(uint32_t *serial, uint32_t len);
+uint8_t flash_read_user_signature(uint32_t *sig, uint32_t len);
 
 
 #endif

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -354,13 +354,6 @@ static void tests_device(void)
     api_format_send_cmd(cmd_str(CMD_bootloader), "", PASSWORD_STAND);
     u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_IO_INVALID_CMD));
 
-    api_format_send_cmd(cmd_str(CMD_bootloader), attr_str(ATTR_unlock), PASSWORD_STAND);
-    u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
-
-    api_format_send_cmd(cmd_str(CMD_bootloader), attr_str(ATTR_lock), PASSWORD_STAND);
-    u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
-
-
     api_format_send_cmd(cmd_str(CMD_seed), "{\"source\":\"create\"}", PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
@@ -398,6 +391,7 @@ static void tests_device(void)
     u_assert_str_has_not(utils_read_decrypted_report(), "\"id\":\"\"");
     u_assert_str_has(utils_read_decrypted_report(), "\"seeded\":true");
     u_assert_str_has(utils_read_decrypted_report(), "\"lock\":true");
+    u_assert_str_has(utils_read_decrypted_report(), "\"bootlock\":true");
 
     api_format_send_cmd(cmd_str(CMD_reset), attr_str(ATTR___ERASE__), PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
@@ -415,6 +409,23 @@ static void tests_device(void)
     u_assert_str_has(utils_read_decrypted_report(), "\"id\":\"\"");
     u_assert_str_has(utils_read_decrypted_report(), "\"seeded\":false");
     u_assert_str_has(utils_read_decrypted_report(), "\"lock\":false");
+    u_assert_str_has(utils_read_decrypted_report(), "\"bootlock\":true");
+
+    api_format_send_cmd(cmd_str(CMD_bootloader), attr_str(ATTR_unlock), PASSWORD_STAND);
+    u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+
+    if (TEST_LIVE_DEVICE) {
+        api_format_send_cmd(cmd_str(CMD_device), attr_str(ATTR_info), PASSWORD_STAND);
+        u_assert_str_has(utils_read_decrypted_report(), "\"bootlock\":false");
+    }
+
+    api_format_send_cmd(cmd_str(CMD_bootloader), attr_str(ATTR_lock), PASSWORD_STAND);
+    u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+
+    if (TEST_LIVE_DEVICE) {
+        api_format_send_cmd(cmd_str(CMD_device), attr_str(ATTR_info), PASSWORD_STAND);
+        u_assert_str_has(utils_read_decrypted_report(), "\"bootlock\":true");
+    }
 
     api_format_send_cmd(cmd_str(CMD_reset), attr_str(ATTR___ERASE__), PASSWORD_NONE);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));


### PR DESCRIPTION
The new JSON field is `bootlock` with values of `true` for locked and `false` for unlocked bootloader.

Sending
```
{"device":"info"}
```

Returns
```
{ 
  "device": {
    "serial": "00313453434d59593133303033303434", 
    "version": "v1.2.0-104-gb609385", 
    "name": "Digital Bitbox", 
    "id": "694383184e6e598debd221ec4f886424b9f78daf8b3e1cd6adf24c8795249fce", 
    "seeded": true, 
    "lock": false, 
    "bootlock": true, 
    "sdcard": false
  }
}
```
