### PR TITLE
mpu

### DIFF
--- a/firmware.ld
+++ b/firmware.ld
@@ -5,7 +5,7 @@ SEARCH_DIR(.)
 /* Memory Spaces Definitions */
 MEMORY
 {
-	rom (rx)  : ORIGIN = 0x00408000, LENGTH = 0x00038000
+	rom (rx)  : ORIGIN = 0x00409000, LENGTH = 0x00037000
 	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 0x00010000
 }
 

--- a/src/bootloader.h
+++ b/src/bootloader.h
@@ -32,6 +32,17 @@
 #include <stdint.h>
 
 
+#define MPU_REGION_VALID            (0x10)
+#define MPU_REGION_ENABLE           (0x01)
+#define MPU_REGION_NORMAL           (8 << 16)// TEX:0b001 S:0b0 C:0b0 B:0b0
+#define MPU_REGION_STATE_NA         (0x00 << 24)// No access
+#define MPU_REGION_STATE_PRIV_RW    (0x01 << 24)
+#define MPU_REGION_STATE_RW         (0x03 << 24)
+#define MPU_REGION_STATE_PRIV_RO    (0x05 << 24)
+#define MPU_REGION_STATE_RO         (0x06 << 24)
+#define MPU_REGION_STATE_XN         (0x01 << 28)
+
+
 typedef enum BOOT_OP_CODES {
     OP_WRITE = 'w',/* 0x77 */
     OP_ERASE = 'e',/* 0x65 */

--- a/src/drivers/sam/services/flash_efc/flash_efc.c
+++ b/src/drivers/sam/services/flash_efc/flash_efc.c
@@ -616,7 +616,7 @@ uint32_t flash_write(uint32_t ul_address, const void *p_buffer,
 	/* Write all pages */
 	while (ul_size > 0) {
 		/* Copy data in temporary buffer to avoid alignment problems. */
-		writeSize = Min((uint32_t) IFLASH_PAGE_SIZE - us_offset - 1,
+		writeSize = Min((uint32_t) IFLASH_PAGE_SIZE - us_offset,
 				ul_size);
 		compute_address(p_efc, us_page, 0, &ul_page_addr);
 		us_padding = IFLASH_PAGE_SIZE - us_offset - writeSize;

--- a/src/firmware.c
+++ b/src/firmware.c
@@ -24,6 +24,7 @@
 
 */
 
+
 #include <stdint.h>
 #include "drivers/config/conf_usb.h"
 #include "drivers/config/mcu.h"
@@ -68,11 +69,11 @@ int main (void)
     ataes_init();
     __stack_chk_guard = random_uint32(0);
     flash_init(FLASH_ACCESS_MODE_128, 6);
-    pmc_enable_periph_clk(ID_PIOA); // Button input
+    pmc_enable_periph_clk(ID_PIOA);
     usb_suspend_action();
     udc_start();
     delay_init(F_CPU);
-    memory_setup(); // One time factory setup
+    memory_setup();
     systick_init();
     touch_init();
     ecc_context_init();
@@ -83,7 +84,7 @@ int main (void)
     delay_ms(300);
     led_off();
 
-    while (true) {
+    while (1) {
         sleepmgr_enter_sleep();
     }
 }

--- a/src/flags.h
+++ b/src/flags.h
@@ -33,18 +33,18 @@
 #ifndef IFLASH0_ADDR
 #define IFLASH0_ADDR                (0x00400000u)
 #endif
-#ifndef FLASH_USER_SIG_SIZE
-#define FLASH_USER_SIG_SIZE         (512)
-#endif
+#define FLASH_BOOT_START            (IFLASH0_ADDR)
 #define FLASH_BOOT_LEN              (0x00008000u)
-#define FLASH_APP_START             (IFLASH0_ADDR + FLASH_BOOT_LEN)
-#define FLASH_APP_LEN               (IFLASH0_SIZE - FLASH_BOOT_LEN)
+#define FLASH_SIG_START             (IFLASH0_ADDR + FLASH_BOOT_LEN)
+#define FLASH_SIG_LEN               (0x00001000u)// note: min flash erase size is 0x1000 (8 512-Byte pages))
+#define FLASH_APP_START             (IFLASH0_ADDR + FLASH_BOOT_LEN + FLASH_SIG_LEN)
+#define FLASH_APP_LEN               (IFLASH0_SIZE - FLASH_BOOT_LEN - FLASH_SIG_LEN)
 #define FLASH_APP_PAGE_NUM          (FLASH_APP_LEN / IFLASH0_PAGE_SIZE)
 #define FLASH_BOOT_OP_LEN           (2)// 1 byte op code and 1 byte parameter
 #define FLASH_BOOT_PAGES_PER_CHUNK  (8)
 #define FLASH_BOOT_CHUNK_LEN        (IFLASH0_PAGE_SIZE * FLASH_BOOT_PAGES_PER_CHUNK)
 #define FLASH_BOOT_CHUNK_NUM        (FLASH_APP_LEN / FLASH_BOOT_CHUNK_LEN)// app len should be a multiple of chunk len
-#define FLASH_BOOT_LOCK_BYTE        (FLASH_USER_SIG_SIZE - 1)
+#define FLASH_BOOT_LOCK_BYTE        (FLASH_SIG_LEN - 1)
 
 
 #define AES_DATA_LEN_MAX 1024// base64 increases size by ~4/3; AES encryption by max 32 char

--- a/src/memory.c
+++ b/src/memory.c
@@ -68,7 +68,7 @@ static void memory_mempass(void)
     // Encrypt data saved to memory using an AES key obfuscated by the
     // bootloader bytes.
 #ifndef TESTING
-    sha256_Raw((uint8_t *)(IFLASH0_ADDR), FLASH_BOOT_LEN, mempass);
+    sha256_Raw((uint8_t *)(FLASH_BOOT_START), FLASH_BOOT_LEN, mempass);
 #endif
     sha256_Raw(mempass, 32, mempass);
     memory_write_aeskey(utils_uint8_to_hex(mempass, sizeof(mempass)), sizeof(mempass) * 2,

--- a/src/sham.c
+++ b/src/sham.c
@@ -120,10 +120,3 @@ uint8_t flash_read_unique_id(uint32_t *serial, uint32_t len)
     memset(serial, 1, sizeof(uint32_t) * len);
     return 0; // success
 }
-
-
-uint8_t flash_read_user_signature(uint32_t *sig, uint32_t len)
-{
-    memset(sig, 0, sizeof(uint32_t) * len);
-    return 0;
-}

--- a/src/sham.h
+++ b/src/sham.h
@@ -41,7 +41,6 @@ uint8_t sd_present(void);
 uint8_t sd_erase(int cmd);
 uint8_t touch_button_press(uint8_t touch_type);
 uint8_t flash_read_unique_id(uint32_t *serial, uint32_t len);
-uint8_t flash_read_user_signature(uint32_t *sig, uint32_t len);
 
 
 #endif

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -354,6 +354,9 @@ static void tests_device(void)
     api_format_send_cmd(cmd_str(CMD_bootloader), "", PASSWORD_STAND);
     u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_IO_INVALID_CMD));
 
+    api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), PASSWORD_STAND);
+    u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+
     api_format_send_cmd(cmd_str(CMD_seed), "{\"source\":\"create\"}", PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
@@ -386,12 +389,12 @@ static void tests_device(void)
     u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_sdcard));
     u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_serial));
     u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_version));
+    u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_bootlock));
     u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_name));
     u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_id));
     u_assert_str_has_not(utils_read_decrypted_report(), "\"id\":\"\"");
     u_assert_str_has(utils_read_decrypted_report(), "\"seeded\":true");
     u_assert_str_has(utils_read_decrypted_report(), "\"lock\":true");
-    u_assert_str_has(utils_read_decrypted_report(), "\"bootlock\":true");
 
     api_format_send_cmd(cmd_str(CMD_reset), attr_str(ATTR___ERASE__), PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
@@ -404,12 +407,12 @@ static void tests_device(void)
     u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_sdcard));
     u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_serial));
     u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_version));
+    u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_bootlock));
     u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_name));
     u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_id));
     u_assert_str_has(utils_read_decrypted_report(), "\"id\":\"\"");
     u_assert_str_has(utils_read_decrypted_report(), "\"seeded\":false");
     u_assert_str_has(utils_read_decrypted_report(), "\"lock\":false");
-    u_assert_str_has(utils_read_decrypted_report(), "\"bootlock\":true");
 
     api_format_send_cmd(cmd_str(CMD_bootloader), attr_str(ATTR_unlock), PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));


### PR DESCRIPTION
Assign bootloader region as readonly using the mpu.
Note that the firmware size shrunk by 0x1000 bytes, which will affect code used to sign the firmware.

(The other commit reverting flash_efc.c reverses fixing a false positive result from the coverity static analysis.)