### PR TITLE
erase single file on sd card

### DIFF
--- a/src/flags.h
+++ b/src/flags.h
@@ -97,6 +97,7 @@ X(decrypt)        \
 X(encrypt)        \
 X(script)         \
 X(value)          \
+X(erase)          \
 X(sig)            \
 X(pin)            \
 /* placeholder  */\

--- a/src/sd.h
+++ b/src/sd.h
@@ -30,9 +30,9 @@
 
 uint8_t sd_list(int cmd);
 uint8_t sd_present(void);
-uint8_t sd_erase(int cmd);
-char *sd_load(const char *f, uint16_t f_len, int cmd);
-uint8_t sd_write(const char *f, uint16_t f_len, const char *text, uint16_t t_len,
+uint8_t sd_erase(int cmd, const char *fn);
+char *sd_load(const char *fn, int cmd);
+uint8_t sd_write(const char *fn, const char *text, uint16_t t_len,
                  uint8_t replace, int cmd);
 
 #endif

--- a/src/sham.c
+++ b/src/sham.c
@@ -30,6 +30,7 @@
 
 #include "sham.h"
 #include "flags.h"
+#include "utils.h"
 #include "commander.h"
 
 
@@ -42,27 +43,27 @@ void delay_ms(int delay)
 }
 
 
-uint8_t sd_write(const char *f, uint16_t f_len, const char *t, uint16_t t_len,
+uint8_t sd_write(const char *fn, const char *t, uint16_t t_len,
                  uint8_t replace, int cmd)
 {
     (void) cmd;
     (void) replace;
     memset(sd_filename, 0, sizeof(sd_filename));
     memset(sd_text, 0, sizeof(sd_text));
-    snprintf(sd_filename, sizeof(sd_filename), "%.*s", f_len, f);
+    snprintf(sd_filename, sizeof(sd_filename), "%.*s", (int)strlens(fn), fn);
     snprintf(sd_text, sizeof(sd_text), "%.*s", t_len, t);
     commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
     return DBB_OK;
 }
 
 
-char *sd_load(const char *f, uint16_t f_len, int cmd)
+char *sd_load(const char *fn, int cmd)
 {
     (void) cmd;
     static char text[sizeof(sd_text)];
     memcpy(text, sd_text, sizeof(sd_text));
     commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
-    if (!strncmp(sd_filename, f, f_len)) {
+    if (!strncmp(sd_filename, fn, strlens(fn))) {
         return text;
     }
     return NULL;
@@ -86,9 +87,10 @@ uint8_t sd_present(void)
 }
 
 
-uint8_t sd_erase(int cmd)
+uint8_t sd_erase(int cmd, const char *fn)
 {
     (void) cmd;
+    (void) fn;
     commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
     memset(sd_filename, 0, sizeof(sd_filename));
     memset(sd_text, 0, sizeof(sd_text));

--- a/src/sham.h
+++ b/src/sham.h
@@ -33,12 +33,12 @@
 
 
 void delay_ms(int delay);
-uint8_t sd_write(const char *f, uint16_t f_len, const char *t, uint16_t t_len,
+uint8_t sd_write(const char *f, const char *t, uint16_t t_len,
                  uint8_t replace, int cmd);
-char *sd_load(const char *f, uint16_t f_len, int cmd);
+char *sd_load(const char *f, int cmd);
 uint8_t sd_list(int cmd);
 uint8_t sd_present(void);
-uint8_t sd_erase(int cmd);
+uint8_t sd_erase(int cmd, const char *fn);
 uint8_t touch_button_press(uint8_t touch_type);
 uint8_t flash_read_unique_id(uint32_t *serial, uint32_t len);
 


### PR DESCRIPTION
Currently, erase would erase all backup files.

To instead erase a single file: `{"backup": {"erase": "backup.bak"}}` 

As before, `{"backup": "erase"}` will erase all backup files.
