### PR TITLE
option to check if sd card backup file matches seeded wallet

### DIFF
--- a/src/flags.h
+++ b/src/flags.h
@@ -98,6 +98,7 @@ X(encrypt)        \
 X(script)         \
 X(value)          \
 X(erase)          \
+X(check)          \
 X(sig)            \
 X(pin)            \
 /* placeholder  */\
@@ -217,6 +218,7 @@ X(ERR_SD_WRITE_LEN,    406, "Text to write is too large.")\
 X(ERR_SD_READ_FILE,    407, "Could not read the file.")\
 X(ERR_SD_ERASE,        408, "May not have erased all files (or no file present).")\
 X(ERR_SD_NUM_FILES,    409, "Too many files to read. The list is truncated.")\
+X(ERR_SD_NO_MATCH,     410, "Backup file does not match wallet.")\
 X(ERR_MEM_ATAES,       500, "Chip communication error.")\
 X(ERR_MEM_FLASH,       501, "Could not read flash.")\
 X(ERR_MEM_ENCRYPT,     502, "Could not encrypt.")\

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -46,7 +46,8 @@ int U_TESTS_FAIL = 0;
 
 static void tests_seed_xpub_backup(void)
 {
-    char xpub0[112], xpub1[112], *echo, seed_c[512], seed_b[512], back[512], erase_file[512];
+    char xpub0[112], xpub1[112], *echo;
+    char seed_c[512], seed_b[512], back[512], check[512], erase_file[512];
     char filename[] = "tests_backup.txt";
     char keypath[] = "m/44\'/0\'/";
     char seed_create[] =
@@ -71,11 +72,14 @@ static void tests_seed_xpub_backup(void)
         memset(seed_c, 0, sizeof(seed_c));
         memset(seed_b, 0, sizeof(seed_b));
         memset(back, 0, sizeof(back));
+        memset(check, 0, sizeof(check));
 
         snprintf(seed_c, sizeof(seed_c), "{\"source\":\"%s\"}", attr_str(ATTR_create));
         snprintf(seed_b, sizeof(seed_b), "{\"source\":\"%s\",\"decrypt\":\"%s\"}", filename,
                  *cipher);
         snprintf(back, sizeof(back), "{\"filename\":\"%s\",\"encrypt\":\"%s\"}", filename,
+                 *cipher);
+        snprintf(check, sizeof(check), "{\"check\":\"%s\",\"decrypt\":\"%s\"}", filename,
                  *cipher);
 
         // erase
@@ -143,11 +147,17 @@ static void tests_seed_xpub_backup(void)
         api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), PASSWORD_STAND);
         u_assert_str_has(utils_read_decrypted_report(), filename);
 
+        api_format_send_cmd(cmd_str(CMD_backup), check, PASSWORD_STAND);
+        u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_success));
+
         api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), PASSWORD_STAND);
         u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
         api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), PASSWORD_STAND);
         u_assert_str_has_not(utils_read_decrypted_report(), filename);
+
+        api_format_send_cmd(cmd_str(CMD_backup), check, PASSWORD_STAND);
+        u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_success));
 
         run += 2;
         cipher += 2;
@@ -220,6 +230,19 @@ static void tests_seed_xpub_backup(void)
     memcpy(xpub0, api_read_value(CMD_xpub), sizeof(xpub0));
     u_assert_str_not_eq(xpub0, xpub1);
 
+    api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), PASSWORD_STAND);
+    u_assert_str_has_not(utils_read_decrypted_report(), filename);
+
+    snprintf(back, sizeof(back), "{\"filename\":\"%s\"}", filename);
+
+    api_format_send_cmd(cmd_str(CMD_backup), back, PASSWORD_STAND);
+    u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+
+    snprintf(check, sizeof(check), "{\"check\":\"%s\"}", filename);
+
+    api_format_send_cmd(cmd_str(CMD_backup), check, PASSWORD_STAND);
+    u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_success));
+
     api_format_send_cmd(cmd_str(CMD_seed), seed_create, PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
@@ -228,15 +251,17 @@ static void tests_seed_xpub_backup(void)
     memcpy(xpub1, api_read_value(CMD_xpub), sizeof(xpub0));
     u_assert_str_not_eq(xpub0, xpub1);
 
-    // check backup erase single file
-    api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), PASSWORD_STAND);
-    u_assert_str_has_not(utils_read_decrypted_report(), filename);
+    api_format_send_cmd(cmd_str(CMD_backup), check, PASSWORD_STAND);
+    if (TEST_LIVE_DEVICE) {
+        u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_SD_NO_MATCH));
+    }
 
-    memset(back, 0, sizeof(back));
-    snprintf(back, sizeof(back), "{\"filename\":\"%s\"}", filename);
-
-    api_format_send_cmd(cmd_str(CMD_backup), back, PASSWORD_STAND);
-    u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+    // test erase single backup file
+    if (!TEST_LIVE_DEVICE) {
+        // testing buffer gets overwritten by seed command, so reset it
+        api_format_send_cmd(cmd_str(CMD_backup), back, PASSWORD_STAND);
+        u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+    }
 
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), PASSWORD_STAND);
     u_assert_str_has(utils_read_decrypted_report(), filename);


### PR DESCRIPTION
**send**
```
{
  "backup": {
    "check": "[filename]"
  }
}
```

**reply**
```
{"backup": "success"}
```

If the backup does not match the wallet seed:
```
{ 
  "error": {
    "message": "Backup file does not match wallet.", 
    "code": 410, 
    "command": "backup"
  }
}
```
