### PR TITLE
key stretch pw for encrypted sd card backup files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ set(DBB-FIRMWARE-SOURCES
         aes.c
         base58.c
         base64.c
+        pbkdf2.c
         bip32.c
         commander.c
         hmac.c

--- a/src/memory.c
+++ b/src/memory.c
@@ -54,9 +54,10 @@ __extension__ static uint8_t MEM_aeskey_stand[] = {[0 ... MEM_PAGE_LEN - 1] = 0x
 __extension__ static uint8_t MEM_aeskey_crypt[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
 __extension__ static uint8_t MEM_aeskey_verify[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
 __extension__ static uint8_t MEM_aeskey_memory[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
-__extension__ static uint8_t MEM_name[] = {[0 ... MEM_PAGE_LEN - 1] = '0'};
-__extension__ static uint8_t MEM_master[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
+__extension__ static uint8_t MEM_aeskey_stand_stretch[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
 __extension__ static uint8_t MEM_master_chain[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
+__extension__ static uint8_t MEM_master[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
+__extension__ static uint8_t MEM_name[] = {[0 ... MEM_PAGE_LEN - 1] = '0'};
 
 __extension__ const uint8_t MEM_PAGE_ERASE[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
 __extension__ const uint16_t MEM_PAGE_ERASE_2X[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFFFF};
@@ -124,6 +125,7 @@ void memory_erase(void)
     memory_mempass();
     memory_create_verifypass();
     memory_write_aeskey((const char *)MEM_PAGE_ERASE, MEM_PAGE_LEN, PASSWORD_STAND);
+    memory_write_aeskey((const char *)MEM_PAGE_ERASE, MEM_PAGE_LEN, PASSWORD_STAND_STRETCH);
     memory_write_aeskey((const char *)MEM_PAGE_ERASE, MEM_PAGE_LEN, PASSWORD_CRYPT);
     memory_erase_seed();
     memory_name("Digital Bitbox");
@@ -144,8 +146,9 @@ void memory_clear(void)
     memcpy(MEM_aeskey_stand, MEM_PAGE_ERASE, MEM_PAGE_LEN);
     memcpy(MEM_aeskey_crypt, MEM_PAGE_ERASE, MEM_PAGE_LEN);
     memcpy(MEM_aeskey_verify, MEM_PAGE_ERASE, MEM_PAGE_LEN);
-    memcpy(MEM_master, MEM_PAGE_ERASE, MEM_PAGE_LEN);
+    memcpy(MEM_aeskey_stand_stretch, MEM_PAGE_ERASE, MEM_PAGE_LEN);
     memcpy(MEM_master_chain, MEM_PAGE_ERASE, MEM_PAGE_LEN);
+    memcpy(MEM_master, MEM_PAGE_ERASE, MEM_PAGE_LEN);
 #endif
 }
 
@@ -337,6 +340,10 @@ int memory_write_aeskey(const char *password, int len, PASSWORD_ID id)
         case PASSWORD_STAND:
             ret = memory_eeprom_crypt(password_b, MEM_aeskey_stand, MEM_AESKEY_STAND_ADDR);
             break;
+        case PASSWORD_STAND_STRETCH:
+            ret = memory_eeprom_crypt(password_b, MEM_aeskey_stand_stretch,
+                                      MEM_AESKEY_STAND_STRETCH_ADDR);
+            break;
         case PASSWORD_CRYPT:
             ret = memory_eeprom_crypt(password_b, MEM_aeskey_crypt, MEM_AESKEY_CRYPT_ADDR);
             break;
@@ -361,6 +368,7 @@ void memory_load_aeskeys(void)
     memory_eeprom_crypt(NULL, MEM_aeskey_stand, MEM_AESKEY_STAND_ADDR);
     memory_eeprom_crypt(NULL, MEM_aeskey_crypt, MEM_AESKEY_CRYPT_ADDR);
     memory_eeprom_crypt(NULL, MEM_aeskey_verify, MEM_AESKEY_VERIFY_ADDR);
+    memory_eeprom_crypt(NULL, MEM_aeskey_stand_stretch, MEM_AESKEY_STAND_STRETCH_ADDR);
 }
 
 uint8_t *memory_report_aeskey(PASSWORD_ID id)
@@ -372,6 +380,8 @@ uint8_t *memory_report_aeskey(PASSWORD_ID id)
             return MEM_aeskey_2FA;
         case PASSWORD_STAND:
             return MEM_aeskey_stand;
+        case PASSWORD_STAND_STRETCH:
+            return MEM_aeskey_stand_stretch;
         case PASSWORD_CRYPT:
             return MEM_aeskey_crypt;
         case PASSWORD_VERIFY:

--- a/src/memory.h
+++ b/src/memory.h
@@ -31,34 +31,36 @@
 
 #include <stdint.h>
 
-#define MEM_PAGE_LEN                32
+#define MEM_PAGE_LEN      32
 
 // User Zones: 0x0000 to 0x0FFF
-#define MEM_ERASED_ADDR             0x0000// Zone 0
-#define MEM_SETUP_ADDR              0x0002
-#define MEM_ACCESS_ERR_ADDR         0x0004
-#define MEM_PIN_ERR_ADDR            0x0006
-#define MEM_UNLOCKED_ADDR           0x0008
-#define MEM_NAME_ADDR               0x0100// Zone 1
-#define MEM_MASTER_BIP32_ADDR       0x0200// Zone 2
-#define MEM_MASTER_BIP32_CHAIN_ADDR 0x0300// Zone 3
-#define MEM_AESKEY_STAND_ADDR       0x0400// Zone 4
-#define MEM_AESKEY_VERIFY_ADDR      0x0500// Zone 5
-#define MEM_AESKEY_CRYPT_ADDR       0x0600// Zone 6
+#define MEM_ERASED_ADDR                 0x0000// Zone 0
+#define MEM_SETUP_ADDR                  0x0002
+#define MEM_ACCESS_ERR_ADDR             0x0004
+#define MEM_PIN_ERR_ADDR                0x0006
+#define MEM_UNLOCKED_ADDR               0x0008
+#define MEM_NAME_ADDR                   0x0100// Zone 1
+#define MEM_MASTER_BIP32_ADDR           0x0200// Zone 2
+#define MEM_MASTER_BIP32_CHAIN_ADDR     0x0300// Zone 3
+#define MEM_AESKEY_STAND_ADDR           0x0400// Zone 4
+#define MEM_AESKEY_VERIFY_ADDR          0x0500// Zone 5
+#define MEM_AESKEY_CRYPT_ADDR           0x0600// Zone 6
+#define MEM_AESKEY_STAND_STRETCH_ADDR   0x0700// Zone 7
 
 // Default settings
-#define DEFAULT_unlocked            0xFF
-#define DEFAULT_erased              0xFF
-#define DEFAULT_setup               0xFF
+#define DEFAULT_unlocked  0xFF
+#define DEFAULT_erased    0xFF
+#define DEFAULT_setup     0xFF
 
 
 typedef enum PASSWORD_ID {
     PASSWORD_STAND,
+    PASSWORD_STAND_STRETCH, /* for backups */
     PASSWORD_VERIFY,
     PASSWORD_MEMORY,
     PASSWORD_CRYPT,
-    PASSWORD_2FA,    /* only kept in RAM */
-    PASSWORD_NONE    /* keep last */
+    PASSWORD_2FA,  /* only kept in RAM */
+    PASSWORD_NONE  /* keep last */
 } PASSWORD_ID;
 
 

--- a/src/pbkdf2.c
+++ b/src/pbkdf2.c
@@ -1,0 +1,104 @@
+/*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2015 Douglas J. Bakkum
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+
+#include <string.h>
+#include "pbkdf2.h"
+#include "utils.h"
+#include "sha2.h"
+
+
+static void hmac_sha512(const uint8_t *key, const uint32_t keylen, const uint8_t *msg,
+                        const uint32_t msglen, uint8_t *hmac)
+{
+    int i;
+    uint8_t buf[SHA512_BLOCK_LENGTH], o_key_pad[SHA512_BLOCK_LENGTH],
+            i_key_pad[SHA512_BLOCK_LENGTH];
+    SHA512_CTX ctx;
+
+    memset(buf, 0, SHA512_BLOCK_LENGTH);
+    if (keylen > SHA512_BLOCK_LENGTH) {
+        sha512_Raw(key, keylen, buf);
+    } else {
+        memcpy(buf, key, keylen);
+    }
+
+    for (i = 0; i < SHA512_BLOCK_LENGTH; i++) {
+        o_key_pad[i] = buf[i] ^ 0x5c;
+        i_key_pad[i] = buf[i] ^ 0x36;
+    }
+
+    sha512_Init(&ctx);
+    sha512_Update(&ctx, i_key_pad, SHA512_BLOCK_LENGTH);
+    sha512_Update(&ctx, msg, msglen);
+    sha512_Final(buf, &ctx);
+
+    sha512_Init(&ctx);
+    sha512_Update(&ctx, o_key_pad, SHA512_BLOCK_LENGTH);
+    sha512_Update(&ctx, buf, SHA512_DIGEST_LENGTH);
+    sha512_Final(hmac, &ctx);
+
+    memset(buf, 0, sizeof(buf));
+    memset(o_key_pad, 0, sizeof(o_key_pad));
+    memset(i_key_pad, 0, sizeof(i_key_pad));
+}
+
+
+void pbkdf2_hmac_sha512(const uint8_t *pass, int passlen, uint8_t *key, int keylen)
+{
+    uint32_t i, j, k;
+    uint8_t f[PBKDF2_HMACLEN], g[PBKDF2_HMACLEN];
+    uint32_t blocks = keylen / PBKDF2_HMACLEN;
+
+    static uint8_t salt[PBKDF2_SALTLEN + 4];
+    memset(salt, 0, sizeof(salt));
+    memcpy(salt, PBKDF2_SALT, strlens(PBKDF2_SALT));
+
+    if (keylen & (PBKDF2_HMACLEN - 1)) {
+        blocks++;
+    }
+    for (i = 1; i <= blocks; i++) {
+        salt[PBKDF2_SALTLEN    ] = (i >> 24) & 0xFF;
+        salt[PBKDF2_SALTLEN + 1] = (i >> 16) & 0xFF;
+        salt[PBKDF2_SALTLEN + 2] = (i >> 8) & 0xFF;
+        salt[PBKDF2_SALTLEN + 3] = i & 0xFF;
+        hmac_sha512(pass, passlen, salt, PBKDF2_SALTLEN + 4, g);
+        memcpy(f, g, PBKDF2_HMACLEN);
+        for (j = 1; j < PBKDF2_ROUNDS; j++) {
+            hmac_sha512(pass, passlen, g, PBKDF2_HMACLEN, g);
+            for (k = 0; k < PBKDF2_HMACLEN; k++) {
+                f[k] ^= g[k];
+            }
+        }
+        if (i == blocks && (keylen & (PBKDF2_HMACLEN - 1))) {
+            memcpy(key + PBKDF2_HMACLEN * (i - 1), f, keylen & (PBKDF2_HMACLEN - 1));
+        } else {
+            memcpy(key + PBKDF2_HMACLEN * (i - 1), f, PBKDF2_HMACLEN);
+        }
+    }
+    memset(f, 0, sizeof(f));
+    memset(g, 0, sizeof(g));
+}

--- a/src/pbkdf2.h
+++ b/src/pbkdf2.h
@@ -1,0 +1,44 @@
+/*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2015 Douglas J. Bakkum
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+
+#ifndef _PBKDF2_H_
+#define _PBKDF2_H_
+
+
+#include <stdint.h>
+
+
+#define PBKDF2_SALT     "Digital Bitbox"
+#define PBKDF2_SALTLEN  14
+#define PBKDF2_ROUNDS   2048
+#define PBKDF2_HMACLEN  64
+
+
+void pbkdf2_hmac_sha512(const uint8_t *pass, int passlen, uint8_t *key, int keylen);
+
+
+#endif

--- a/tests/tests_unit.c
+++ b/tests/tests_unit.c
@@ -37,6 +37,7 @@
 #include "base64.h"
 #include "base58.h"
 #include "base64.h"
+#include "pbkdf2.h"
 #include "flags.h"
 #include "bip32.h"
 #include "utils.h"
@@ -467,6 +468,39 @@ static void test_rfc6979(void)
                        "1f4b84c23a86a221d233f2521be018d9318639d5b8bbd6374a8a59232d16ad3d");
 }
 #endif
+
+
+// generated using http://althenia.net/svn/stackoverflow/pbkdf2-test-vectors.py?rev=6
+static void test_pbkdf2(void)
+{
+    uint8_t key[PBKDF2_HMACLEN];
+
+    pbkdf2_hmac_sha512((const uint8_t *)"Digital Bitbox", 14, key, sizeof(key));
+    u_assert_mem_eq(key,
+                    utils_hex_to_uint8("9288a7e3259a0bfb826e5008ffb4109919752bc905b64764e7969a5a8edae970eaa2e4c66535e0df8a251459d83e51af61233a9b87166f4571f17a39c0ddd1e5"),
+                    32);
+
+    pbkdf2_hmac_sha512((const uint8_t *)"password", 8, key, sizeof(key));
+    u_assert_mem_eq(key,
+                    utils_hex_to_uint8("427950427b3c825d16e3c420d6d08c060d34f6d2c7d97acc385a74fe19a0289fad262b524f044a9014ee22b398a0ca17f5af889f356454b2fa678aa56840d653"),
+                    32);
+
+    pbkdf2_hmac_sha512((const uint8_t *)"passwordPASSWORDpassword", 24, key, sizeof(key));
+    u_assert_mem_eq(key,
+                    utils_hex_to_uint8("58a2d64016162fe09fec8d2230f60d9e44f8e8f6cb97cfc0239f58a5bb001b0f02235d12e1f9946895a089b0d2acde1506e185d9cd59034f6e57dbdb626dbea2"),
+                    32);
+
+    pbkdf2_hmac_sha512((const uint8_t *)"pass\0word", 9, key, sizeof(key));
+    u_assert_mem_eq(key,
+                    utils_hex_to_uint8("98fa4a21945c5144b62ab11a78b8bb8295314ee33839370911a653ea0c751fc7fe7afde1076ce24974d5a5ec2d4f3f20642ad6b48e873ab73c861a69656bab0c"),
+                    32);
+
+    pbkdf2_hmac_sha512((const uint8_t *)"{:;}\"'()@#$,./?\\%^&*!<>|~`}", 27, key,
+                       sizeof(key));
+    u_assert_mem_eq(key,
+                    utils_hex_to_uint8("03277346174bced652f3f6c6810c5d4750db208bc6f44a9031e6b737c3ce0942b822c90aad129b541e9e884e4cf337c0d15cbdc5967f1603ef21d1f2f39000bf"),
+                    32);
+}
 
 
 static void test_sign_speed(void)
@@ -964,6 +998,7 @@ int main(void)
     u_run_test(test_ecdh);
     u_run_test(test_bip32_vector_1);
     u_run_test(test_bip32_vector_2);
+    u_run_test(test_pbkdf2);
     u_run_test(test_base58);
     u_run_test(test_base64);
     u_run_test(test_address);


### PR DESCRIPTION
(does not affect dbb app or USB HID API in general)

Use pbkdf2-hmac-sha512 to stretch the user password for encrypting backups on the SD card. 