### PR TITLE
overhaul signing verification

### DIFF
--- a/src/drivers/common/services/usb/class/hid/device/generic/udi_hid_generic.c
+++ b/src/drivers/common/services/usb/class/hid/device/generic/udi_hid_generic.c
@@ -307,6 +307,7 @@ static void udi_hid_generic_report_in_sent(udd_ep_status_t status,
 	UNUSED(nb_sent);
 	UNUSED(ep);
 	udi_hid_generic_b_report_in_free = true;
+    UDI_HID_GENERIC_REPORT_SENT();
 }
 
 //@}

--- a/src/drivers/config/conf_usb.h
+++ b/src/drivers/config/conf_usb.h
@@ -69,6 +69,7 @@
 #define  UDI_HID_GENERIC_DISABLE_EXT()       usb_disable()
 #define  UDI_HID_GENERIC_REPORT_OUT(ptr)     usb_report(ptr)
 #define  UDI_HID_GENERIC_SET_FEATURE(report) usb_hid_set_feature(report)
+#define  UDI_HID_GENERIC_REPORT_SENT()       usb_report_sent()
 
 
 #ifdef BOOTLOADER 

--- a/src/flags.h
+++ b/src/flags.h
@@ -156,10 +156,6 @@ X(NUM)             /* keep last */
 X(OK,                    0, 0)\
 X(ERROR,                 0, 0)\
 X(ERROR_MEM,             0, 0)\
-X(VERIFY_PIN,            0, 0)\
-X(VERIFY_ECHO,           0, 0)\
-X(VERIFY_SAME,           0, 0)\
-X(VERIFY_DIFFERENT,      0, 0)\
 X(TOUCHED,               0, 0)\
 X(NOT_TOUCHED,           0, 0)\
 X(TOUCHED_ABORT,         0, 0)\

--- a/src/memory.c
+++ b/src/memory.c
@@ -49,7 +49,6 @@ static uint8_t MEM_setup = DEFAULT_setup;
 static uint16_t MEM_pin_err = DBB_ACCESS_INITIALIZE;
 static uint16_t MEM_access_err = DBB_ACCESS_INITIALIZE;
 
-__extension__ static uint8_t MEM_aeskey_2FA[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
 __extension__ static uint8_t MEM_aeskey_stand[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
 __extension__ static uint8_t MEM_aeskey_crypt[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
 __extension__ static uint8_t MEM_aeskey_verify[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
@@ -142,7 +141,6 @@ void memory_clear(void)
     // Zero important variables in RAM on embedded MCU.
     // Do not clear for testing routines (i.e. not embedded).
     memcpy(MEM_name, MEM_PAGE_ERASE, MEM_PAGE_LEN);
-    memcpy(MEM_aeskey_2FA, MEM_PAGE_ERASE, MEM_PAGE_LEN);
     memcpy(MEM_aeskey_stand, MEM_PAGE_ERASE, MEM_PAGE_LEN);
     memcpy(MEM_aeskey_crypt, MEM_PAGE_ERASE, MEM_PAGE_LEN);
     memcpy(MEM_aeskey_verify, MEM_PAGE_ERASE, MEM_PAGE_LEN);
@@ -333,10 +331,6 @@ int memory_write_aeskey(const char *password, int len, PASSWORD_ID id)
             memcpy(MEM_aeskey_memory, password_b, MEM_PAGE_LEN);
             ret = DBB_OK;
             break;
-        case PASSWORD_2FA:
-            memcpy(MEM_aeskey_2FA, password_b, MEM_PAGE_LEN);
-            ret = DBB_OK;
-            break;
         case PASSWORD_STAND:
             ret = memory_eeprom_crypt(password_b, MEM_aeskey_stand, MEM_AESKEY_STAND_ADDR);
             break;
@@ -376,8 +370,6 @@ uint8_t *memory_report_aeskey(PASSWORD_ID id)
     switch ((int)id) {
         case PASSWORD_MEMORY:
             return MEM_aeskey_memory;
-        case PASSWORD_2FA:
-            return MEM_aeskey_2FA;
         case PASSWORD_STAND:
             return MEM_aeskey_stand;
         case PASSWORD_STAND_STRETCH:

--- a/src/memory.h
+++ b/src/memory.h
@@ -59,7 +59,6 @@ typedef enum PASSWORD_ID {
     PASSWORD_VERIFY,
     PASSWORD_MEMORY,
     PASSWORD_CRYPT,
-    PASSWORD_2FA,  /* only kept in RAM */
     PASSWORD_NONE  /* keep last */
 } PASSWORD_ID;
 

--- a/src/usb.c
+++ b/src/usb.c
@@ -62,6 +62,10 @@ void usb_process(uint16_t framenumber)
     }
 }
 
+void usb_report_sent(void)
+{
+}
+
 void usb_suspend_action(void)
 {
 }

--- a/src/usb.h
+++ b/src/usb.h
@@ -30,6 +30,7 @@
 
 
 void usb_report(const unsigned char *command);
+void usb_report_sent(void);
 void usb_process(uint16_t framenumber);
 bool usb_enable(void);
 void usb_disable(void);

--- a/tests/api.h
+++ b/tests/api.h
@@ -142,8 +142,7 @@ static void api_format_send_cmd(const char *cmd, const char *val, PASSWORD_ID id
 
 static void api_reset_device(void)
 {
-    api_format_send_cmd(cmd_str(CMD_password), tests_pwd,
-                        PASSWORD_NONE);// in case not yet set
+    api_format_send_cmd(cmd_str(CMD_password), tests_pwd, PASSWORD_NONE); // if not set
     api_format_send_cmd(cmd_str(CMD_reset), attr_str(ATTR___ERASE__), PASSWORD_STAND);
 }
 


### PR DESCRIPTION
This PR simplifies the code and adds security for the signing verification process. 

For both locked and unlocked devices, 2 sign commands are required (the recent PIN protocol update required 3 commands). Now, the second sign command no longer needs to be identical to the first because the first sign command is remembered. This guarantees that the verification 'echo' message displayed on a 2FA device will match the data to be signed. 

For locked devices, the second sign command must include the lock PIN. For unlocked devices, the second command can be any valid command and is silently ignored - sending an empty sign command `{"sign":""}` or similar is recommended for keeping client code readable. As before, touch button user confirmation begins on receipt of the second command, and the JSON replies are not changed.


**First sign command (same as before)**
```
{ 
  "sign": 
  {
    "meta": "<<meta data here>>", 
    "data": [
        {"hash":"c6fa4c236f59020ec8ffde22f85a78e7f256e94cd975eb5199a4a5cc73e26e4a", "keypath":"m/44p"},
        {"hash":"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "keypath":"m/44p"}
    ], 
    "checkpub":[
        {"pubkey":"000000000000000000000000000000000000000000000000000000000000000000", "keypath":"m/44p/0p/0p/1/8"},
        {"pubkey":"032ab901fe42a05e970e6d5c701b4d7a6db33b0fa7daaaa709ebe755daf9dfe0ec", "keypath":"m/44p/0p/0p/1/8"}
    ]
  }
}
```

**Second sign command**
```
{ 
  "sign" : 
  {
    "pin": "[pin code]"
  }
}
```
(`pin` is not required unless the device is locked.)

