### PR TITLE
bootloader M of N signature verification of firmware

### DIFF
--- a/src/bootloader.h
+++ b/src/bootloader.h
@@ -42,6 +42,7 @@
 #define MPU_REGION_STATE_RO         (0x06 << 24)
 #define MPU_REGION_STATE_XN         (0x01 << 28)
 
+#define BOOT_SIG_M 2
 
 typedef enum BOOT_OP_CODES {
     OP_WRITE = 'w',/* 0x77 */

--- a/src/flags.h
+++ b/src/flags.h
@@ -36,7 +36,7 @@
 #define FLASH_BOOT_START            (IFLASH0_ADDR)
 #define FLASH_BOOT_LEN              (0x00008000u)
 #define FLASH_SIG_START             (IFLASH0_ADDR + FLASH_BOOT_LEN)
-#define FLASH_SIG_LEN               (0x00001000u)// note: min flash erase size is 0x1000 (8 512-Byte pages))
+#define FLASH_SIG_LEN               (0x00001000u)// note: min flash erase size is 0x1000 (8 512-Byte pages)
 #define FLASH_APP_START             (IFLASH0_ADDR + FLASH_BOOT_LEN + FLASH_SIG_LEN)
 #define FLASH_APP_LEN               (IFLASH0_SIZE - FLASH_BOOT_LEN - FLASH_SIG_LEN)
 #define FLASH_APP_PAGE_NUM          (FLASH_APP_LEN / IFLASH0_PAGE_SIZE)

--- a/src/startup.c
+++ b/src/startup.c
@@ -62,7 +62,7 @@ void HardFault_Handler(void)
 {
     while (1) {
         led_toggle();
-        delay_ms(3000);
+        delay_ms(500);
     }
 }
 

--- a/src/uECC.c
+++ b/src/uECC.c
@@ -1058,7 +1058,7 @@ int uECC_verify_double(const uint8_t *publicKey, const uint8_t *p_signature,
 }
 
 /* Verify an ECDSA signature.
-   Returns 1 if the signature is valid, 0 if it is invalid. */
+   Returns 0 if the signature is valid, 1 if it is invalid. */
 int uECC_verify_digest(const uint8_t *publicKey,
                        const uint8_t p_hash[uECC_BYTES],
                        const uint8_t p_signature[uECC_BYTES * 2])


### PR DESCRIPTION
Currently 2 of 3 but easy to update once secure keys are chosen.

Clients (i.e. dbb-app) operate as before and just concatenate signatures for the extra keys when sending the 's' command to the bootloader. Order is important. For example, if a signature for the second key is missing, a 'dummy' sig, such as 64 bytes of 0xFF, should be inserted before concatenating the signature for the third key, and so on.