### PR TITLE
device:info returns TFA test message

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -922,8 +922,19 @@ static void commander_process_device(yajl_val json_node)
             snprintf(sdcard, sizeof(sdcard), "%s", attr_str(ATTR_false));
         }
 
+        int tfa_len;
+        char *tfa = aes_cbc_b64_encrypt((const unsigned char *)VERIFYPASS_CRYPT_TEST,
+                                        strlens(VERIFYPASS_CRYPT_TEST),
+                                        &tfa_len,
+                                        PASSWORD_VERIFY);
+        if (!tfa) {
+            commander_clear_report();
+            commander_fill_report(cmd_str(CMD_device), NULL, DBB_ERR_MEM_ENCRYPT);
+            return;
+        }
+
         snprintf(msg, sizeof(msg),
-                 "{\"%s\":\"%s\", \"%s\":\"%s\", \"%s\":\"%s\", \"%s\":\"%s\", \"%s\":%s, \"%s\":%s, \"%s\":%s, \"%s\":%s}",
+                 "{\"%s\":\"%s\", \"%s\":\"%s\", \"%s\":\"%s\", \"%s\":\"%s\", \"%s\":%s, \"%s\":%s, \"%s\":%s, \"%s\":%s, \"%s\":\"%s\"}",
                  attr_str(ATTR_serial), utils_uint8_to_hex((uint8_t *)serial, sizeof(serial)),
                  attr_str(ATTR_version), DIGITAL_BITBOX_VERSION,
                  attr_str(ATTR_name), (char *)memory_name(""),
@@ -931,8 +942,10 @@ static void commander_process_device(yajl_val json_node)
                  attr_str(ATTR_seeded), seeded,
                  attr_str(ATTR_lock), lock,
                  attr_str(ATTR_bootlock), bootlock,
-                 attr_str(ATTR_sdcard), sdcard);
+                 attr_str(ATTR_sdcard), sdcard,
+                 attr_str(ATTR_TFA), tfa);
 
+        free(tfa);
         commander_fill_report(cmd_str(CMD_device), msg, DBB_JSON_ARRAY);
         return;
     }

--- a/src/flags.h
+++ b/src/flags.h
@@ -98,7 +98,7 @@ X(pin)            \
 /*  reply keys  */\
 X(ciphertext)     \
 X(echo)           \
-X(2FA)            \
+X(TFA)            \
 X(sham)           \
 X(input)          \
 X(ataes)          \
@@ -137,6 +137,7 @@ X(seeded)         \
 X(serial)         \
 X(version)        \
 X(password)       \
+X(TFA)            \
 X(__ERASE__)      \
 X(__FORCE__)      \
 X(NUM)             /* keep last */
@@ -195,7 +196,7 @@ X(ERR_SIGN_PUBKEY_LEN, 300, "Incorrect pubkey length. A 33-byte hexadecimal valu
 X(ERR_SIGN_HASH_LEN,   301, "Incorrect hash length. A 32-byte hexadecimal value (64 characters) is expected.")\
 X(ERR_SIGN_DESERIAL,   302, "Could not deserialize outputs or wrong change keypath.")\
 X(ERR_SIGN_ECCLIB,     303, "Could not sign.")\
-X(ERR_SIGN_TFA_PIN,    304, "Incorrect 2FA pin.")\
+X(ERR_SIGN_TFA_PIN,    304, "Incorrect TFA pin.")\
 X(ERR_SD_CARD,         400, "Please insert SD card.")\
 X(ERR_SD_MOUNT,        401, "Could not mount the SD card.")\
 X(ERR_SD_OPEN_FILE,    402, "Could not open a file to write - it may already exist.")\


### PR DESCRIPTION
May be convenient for possible future applications for testing if a second factor authentication device is paired. The test message can only be decrypted by a TFA device that was paired to the Digital Bitbox.

Send
```
{ "device":"info" }
```

Reply
```
{ 
  "device": {
    "TFA": "GbS++B3gUAtFRzKFkmg0RiUlFrzzZE5Kq6OlvJHfQfLPhbmrs/A0BeJBMF+UL4Jc",
    "serial": "01010101010101010101010101010101", 
    "version": "v1.2.0-155-g1225f47", 
    "name": "Digital Bitbox", 
    "id": "", 
    "seeded": false, 
    "lock": false, 
    "bootlock": true, 
    "sdcard": true
  }
}

