### PR TITLE
double the usb buffer size to 4096 characters

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -253,7 +253,7 @@ int commander_fill_json_array(const char **key, const char **value, int *type, i
     snprintf(p + strlens(json_array), COMMANDER_ARRAY_MAX - strlens(json_array), "%s",
              array_element);
 
-    if ((strlens(json_array) + 1) > COMMANDER_ARRAY_MAX) {
+    if ((strlens(json_array) + 1) >= COMMANDER_ARRAY_MAX) {
         commander_clear_report();
         commander_fill_report(cmd_str(cmd), NULL, DBB_ERR_IO_REPORT_BUF);
         REPORT_BUF_OVERFLOW = 1;

--- a/src/commander.h
+++ b/src/commander.h
@@ -31,22 +31,6 @@
 
 #include <stdint.h>
 #include "memory.h"
-#ifndef TESTING
-#include "conf_usb.h"
-
-
-#define COMMANDER_REPORT_SIZE       UDI_HID_REPORT_OUT_SIZE
-#else
-#define COMMANDER_REPORT_SIZE       2048
-#endif
-#define COMMANDER_ARRAY_MAX         COMMANDER_REPORT_SIZE
-#define COMMANDER_ARRAY_ELEMENT_MAX 1024
-#define COMMANDER_MAX_ATTEMPTS      15// max PASSWORD or LOCK PIN attempts before device reset
-#define VERIFYPASS_FILENAME         "verification.txt"
-#define VERIFYPASS_CRYPT_TEST       "Digital Bitbox 2FA"
-#define AUTOBACKUP_FILENAME         "autobackup_"
-#define AUTOBACKUP_ENCRYPT          "yes"
-#define AUTOBACKUP_NUM              10
 
 
 char *aes_cbc_b64_encrypt(const unsigned char *in, int inlen, int *out_b64len,

--- a/src/drivers/config/conf_usb.h
+++ b/src/drivers/config/conf_usb.h
@@ -76,8 +76,8 @@
 #define  UDI_HID_REPORT_IN_SIZE             256
 #define  UDI_HID_REPORT_OUT_SIZE            4098
 #else
-#define  UDI_HID_REPORT_IN_SIZE             2048
-#define  UDI_HID_REPORT_OUT_SIZE            2048
+#define  UDI_HID_REPORT_IN_SIZE             4096
+#define  UDI_HID_REPORT_OUT_SIZE            4096
 #endif
 #define  UDI_HID_REPORT_FEATURE_SIZE        8
 #define  UDI_HID_GENERIC_EP_SIZE            64

--- a/src/flags.h
+++ b/src/flags.h
@@ -47,8 +47,23 @@
 #define FLASH_BOOT_LOCK_BYTE        (FLASH_SIG_LEN - 1)
 
 
-#define AES_DATA_LEN_MAX 1024// base64 increases size by ~4/3; AES encryption by max 32 char
-#define PASSWORD_LEN_MIN 4
+#ifndef TESTING
+#include "conf_usb.h"
+#define COMMANDER_REPORT_SIZE       UDI_HID_REPORT_OUT_SIZE
+#else
+#define COMMANDER_REPORT_SIZE       4096
+#endif
+#define COMMANDER_SIG_LEN           219// sig + pubkey + json encoding
+#define COMMANDER_ARRAY_MAX         (COMMANDER_REPORT_SIZE - (COMMANDER_SIG_LEN / 2))
+#define COMMANDER_ARRAY_ELEMENT_MAX 1024
+#define COMMANDER_MAX_ATTEMPTS      15// max PASSWORD or LOCK PIN attempts before device reset
+#define VERIFYPASS_FILENAME         "verification.txt"
+#define VERIFYPASS_CRYPT_TEST       "Digital Bitbox 2FA"
+#define AUTOBACKUP_FILENAME         "autobackup_"
+#define AUTOBACKUP_ENCRYPT          "yes"
+#define AUTOBACKUP_NUM              10
+#define AES_DATA_LEN_MAX            2048// base64 increases size by ~4/3; AES encryption by max 32 char
+#define PASSWORD_LEN_MIN            4
 
 
 #define _STRINGIFY(S) #S

--- a/src/utils.c
+++ b/src/utils.c
@@ -174,6 +174,7 @@ int utils_varint_to_uint64(const char *vi, uint64_t *i)
 
 
 #ifdef TESTING
+#include <assert.h>
 #include "commander.h"
 #include "yajl/src/api/yajl_tree.h"
 
@@ -249,8 +250,8 @@ void utils_send_cmd(const char *command, PASSWORD_ID enc_id)
                                         &encrypt_len,
                                         enc_id);
         char cmd[COMMANDER_REPORT_SIZE] = {0};
-        memcpy(cmd, enc, encrypt_len < COMMANDER_REPORT_SIZE ? encrypt_len :
-               COMMANDER_REPORT_SIZE);
+        assert(encrypt_len < COMMANDER_REPORT_SIZE);
+        memcpy(cmd, enc, encrypt_len);
         free(enc);
         utils_decrypt_report(commander(cmd));
     }

--- a/src/utils.h
+++ b/src/utils.h
@@ -34,7 +34,7 @@
 #include "memory.h"
 
 
-#define TO_UINT8_HEX_BUF_LEN 2048
+#define TO_UINT8_HEX_BUF_LEN COMMANDER_REPORT_SIZE
 #define VARINT_LEN 20
 
 #define strlens(s) (s == NULL ? 0 : strlen(s))


### PR DESCRIPTION
The motivation for this PR is to increase the number of transaction inputs that can be signed in one command. (If a transaction has more inputs, then it must be 'streamed' to the device.)

A transaction with ~~20~~ 18 inputs (`data`) can be signed at one time, assuming meta is a 64-character hash and one output pubkey is checked if present in the wallet (i.e. the change output). 

```
{
  "sign": {
    "meta": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", 
    "checkpub": [
      { "pubkey": "000000000000000000000000000000000000000000000000000000000000000000", "keypath": "m/100203p/45p/0/100" }
    ], 
    "data": [ 
      { "hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "keypath": "m/100203p/45p/0/100" },
      { "hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "keypath": "m/100203p/45p/0/100" },
      { "hash": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef", "keypath": "m/100203p/45p/0/100" },
         ...
    ]
  }
}
```