### PR TITLE
speed up command processing

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -1522,7 +1522,7 @@ static int commander_check_init(const char *encrypted_command)
     }
 
     // Force setting a password before processing any other command.
-    if (!memory_read_erased()) {
+    if (!memory_report_erased()) {
         return DBB_OK;
     }
 
@@ -1556,7 +1556,6 @@ static int commander_check_init(const char *encrypted_command)
 //
 char *commander(const char *command)
 {
-    memory_load_aeskeys();
     commander_clear_report();
     if (commander_check_init(command) == DBB_OK) {
         char *command_dec = commander_decrypt(command);
@@ -1565,7 +1564,6 @@ char *commander(const char *command)
             free(command_dec);
         }
     }
-
     memory_clear();
     return json_report;
 }

--- a/src/firmware.c
+++ b/src/firmware.c
@@ -73,7 +73,6 @@ int main (void)
     usb_suspend_action();
     udc_start();
     delay_init(F_CPU);
-    memory_setup();
     systick_init();
     touch_init();
     ecc_context_init();
@@ -83,6 +82,8 @@ int main (void)
     led_on();
     delay_ms(300);
     led_off();
+
+    memory_setup();
 
     while (1) {
         sleepmgr_enter_sleep();

--- a/src/memory.h
+++ b/src/memory.h
@@ -70,14 +70,13 @@ void memory_clear(void);
 
 int memory_aeskey_is_erased(PASSWORD_ID id);
 int memory_write_aeskey(const char *password, int len, PASSWORD_ID id);
-void memory_load_aeskeys(void);
 uint8_t *memory_report_aeskey(PASSWORD_ID id);
 uint8_t *memory_name(const char *name);
 uint8_t *memory_master(const uint8_t *master_priv_key);
 uint8_t *memory_chaincode(const uint8_t *chain_code);
 
 uint8_t *memory_read_memseed(void);
-uint8_t memory_read_erased(void);
+uint8_t memory_report_erased(void);
 uint8_t memory_read_setup(void);
 uint8_t memory_read_unlocked(void);
 

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -1174,6 +1174,7 @@ int main(void)
     __stack_chk_guard = random_uint32(0);
     ecc_context_init();
     memory_setup();
+    memory_setup(); // run twice
     printf("\n\nInternal API Result:\n");
     run_utests();
 


### PR DESCRIPTION
Reads to the ataes chip are slow. This PR changes initialization reads of data in the ataes chip to occur when the device is plugged in instead of each time a command is received.