### PR TITLE
Reboot command for bootloader

### DIFF
--- a/src/bootloader.c
+++ b/src/bootloader.c
@@ -195,6 +195,11 @@ static void bootloader_blink(void)
     bootloader_report_status(OP_STATUS_OK);
 }
 
+static void bootloader_reboot(void)
+{
+    NVIC_SystemReset();
+}
+
 
 static char *bootloader(const char *command)
 {
@@ -215,6 +220,10 @@ static char *bootloader(const char *command)
 
         case OP_BLINK:
             bootloader_blink();
+            break;
+
+        case OP_REBOOT:
+            bootloader_reboot();
             break;
 
         case OP_WRITE:

--- a/src/bootloader.h
+++ b/src/bootloader.h
@@ -48,6 +48,7 @@ typedef enum BOOT_OP_CODES {
     OP_WRITE = 'w',/* 0x77 */
     OP_ERASE = 'e',/* 0x65 */
     OP_BLINK = 'b',/* 0x62 */
+    OP_REBOOT = 'r',/* 0x72 */
     OP_VERIFY = 's',/* 0x73 */
     OP_VERSION = 'v' /* 0x76 */
 } BOOT_OP_CODES;


### PR DESCRIPTION
Useful during manufacturing - can automatically reboot into firmware after it is loaded.