### PR TITLE
option to set backup filename for seed source:create command

### DIFF
--- a/src/flags.h
+++ b/src/flags.h
@@ -60,8 +60,7 @@
 #define VERIFYPASS_FILENAME         "verification.txt"
 #define VERIFYPASS_CRYPT_TEST       "Digital Bitbox 2FA"
 #define AUTOBACKUP_FILENAME         "autobackup_"
-#define AUTOBACKUP_ENCRYPT          "yes"
-#define AUTOBACKUP_NUM              10
+#define AUTOBACKUP_NUM              50
 #define AES_DATA_LEN_MAX            2048// base64 increases size by ~4/3; AES encryption by max 32 char
 #define PASSWORD_LEN_MIN            4
 


### PR DESCRIPTION
Example:
`{ "seed": {"source":"create", "filename":"filename.bak"} }"`

The PR is backward compatible: a command without a filename falls back to creating a backup with an automatically generated filename (maximum 50 now instead of 10 autobackup files). Sending a filename for older firmware is also ok as it will be silently ignored.