### PR TITLE
unencrypted ping command to test if pw set

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -1522,6 +1522,25 @@ static int commander_check_init(const char *encrypted_command)
         return DBB_ERROR;
     }
 
+    // Pong whether or not password is set
+    if (encrypted_command[0] == '{') {
+        yajl_val json_node = yajl_tree_parse(encrypted_command, NULL, 0);
+        if (json_node && YAJL_IS_OBJECT(json_node)) {
+            const char *path[] = { cmd_str(CMD_ping), NULL };
+            const char *ping = YAJL_GET_STRING(yajl_tree_get(json_node, path, yajl_t_string));
+            if (ping) {
+                if (memory_report_erased()) {
+                    commander_fill_report(cmd_str(CMD_ping), attr_str(ATTR_false), DBB_OK);
+                } else {
+                    commander_fill_report(cmd_str(CMD_ping), attr_str(ATTR_password), DBB_OK);
+                }
+                yajl_tree_free(json_node);
+                return DBB_ERROR;
+            }
+        }
+        yajl_tree_free(json_node);
+    }
+
     // Force setting a password before processing any other command.
     if (!memory_report_erased()) {
         return DBB_OK;

--- a/src/flags.h
+++ b/src/flags.h
@@ -90,6 +90,7 @@ X(device)         \
 X(random)         \
 X(backup)         \
 X(aes256cbc)      \
+X(ping)           \
 /*  child keys  */\
 X(source)         \
 X(type)           \

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -364,8 +364,14 @@ static void tests_device(void)
 {
     api_reset_device();
 
+    api_format_send_cmd(cmd_str(CMD_ping), "", PASSWORD_NONE);
+    u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_false));
+
     api_format_send_cmd(cmd_str(CMD_password), tests_pwd, PASSWORD_NONE);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+
+    api_format_send_cmd(cmd_str(CMD_ping), "", PASSWORD_NONE);
+    u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_password));
 
     api_format_send_cmd(cmd_str(CMD_led), attr_str(ATTR_toggle), PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));


### PR DESCRIPTION
Sending an unencrypted command `{"ping":""}` will return `{"pong":"false"}` or `{"pong":"password"}` depending if the password is set or not.