### PR TITLE
use secp ecc lib by default, with smaller precomputed table for signing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ os:
     - linux
 
 env:
-    - ENV="-DBUILD_TYPE=test -DUSE_UECC_LIB=ON"   TEST=yes
-    - ENV="-DBUILD_TYPE=test -DUSE_UECC_LIB=OFF"  TEST=yes
-    - ENV="-DBUILD_TYPE=firmware -DUSE_UECC_LIB=ON"  TEST=no
-    - ENV="-DBUILD_TYPE=bootloader -DUSE_UECC_LIB=ON"  TEST=no
-#    - ENV="-DBUILD_TYPE=firmware -DUSE_UECC_LIB=OFF" TEST=no # secp lib too big at the moment
+    - ENV="-DBUILD_TYPE=test -DUSE_UECC_LIB=ON"       TEST=yes
+    - ENV="-DBUILD_TYPE=test -DUSE_UECC_LIB=OFF"      TEST=yes
+    - ENV="-DBUILD_TYPE=bootloader -DUSE_UECC_LIB=ON" TEST=no # use the smaller ecc lib
+    - ENV="-DBUILD_TYPE=firmware -DUSE_UECC_LIB=OFF"  TEST=no
+#    - ENV="-DBUILD_TYPE=firmware -DUSE_UECC_LIB=ON"  TEST=no
 
 compiler:
     - clang

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,11 @@ project(${MYPROJECT} C)
 #-----------------------------------------------------------------------------
 # Options for building
 
+if(BUILD_TYPE STREQUAL "bootloader")
 option(USE_UECC_LIB "Use micro ECC instead bitcoin's secp256k1 library." ON)
+else()
+option(USE_UECC_LIB "Use micro ECC instead bitcoin's secp256k1 library." OFF)
+endif()
 option(BUILD_COVERAGE "Compile with test coverage flags." OFF)
 option(BUILD_VALGRIND "Compile with debug symbols." OFF)
 option(BUILD_DOCUMENTATION "Build the Doxygen documentation." OFF)
@@ -90,6 +94,8 @@ endif()
 
 if(USE_UECC_LIB)
     add_definitions(-DECC_USE_UECC_LIB)
+else()
+    add_definitions(-DSECP256K1_BUILD=1)
 endif()
 
 


### PR DESCRIPTION
Use the bitcoin/secp256k1 library for ecc signing.

The library is modified to decrease the precomputed table size by half to 32kB, in order to fit on the MCU, at the expense of running at 75% signing speed. (Ref PR: https://github.com/bitcoin/secp256k1/pull/337)