### PR TITLE
Vagrant: Use a different directory name for the build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
+build-vagrant
 version.h
 .vagrant
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Digital Bitbox Firmware
 
 **MCU code for the [Digital Bitbox](https://digitalbitbox.com) hardware wallet.**
 
-All communication to the hardware wallet enters and exits a single gateway `char *commander(const char *command)` that receives an encrypted command and returns an encrypted reply. The communication protocol is described in the [API](https://digitalbitbox.com/api.html). 
+All communication to the hardware wallet enters and exits a single gateway `char *commander(const char *command)` that receives an encrypted command and returns an encrypted reply. The communication protocol is described in the [API](https://digitalbitbox.com/api.html).
 
 The code can be compiled and tested locally without the need for a device. See the `tests_cmdline.c` code for a simple example and the `tests_api.c` code to test the full API. The `tests_api.c` code will also test a live device if one is plugged into a USB slot. This requires installation of the [hidapi library](http://www.signal11.us/oss/hidapi/) for USB communication, a micro SD card in the device, and a number of touch button presses to permit `erase` and `sign` commands. WARNING: data on the device and micro SD card will be **lost** when running `tests_api.c`.
 
@@ -47,12 +47,12 @@ Requires:
 
 - [Vagrant](http://www.vagrantup.com/downloads)
 - [Virtual Box](https://www.virtualbox.org/wiki/Downloads)
-    
+
 Build:
 
     git clone https://github.com/digitalbitbox/mcu && cd mcu
     vagrant box add ubuntu/trusty32
-    vagrant up # Creates: build/bin/firmware.bin
+    vagrant up # Creates: build-vagrant/bin/firmware.bin
     vagrant halt
     
 
@@ -75,5 +75,3 @@ All commits must be signed with PGP. To set Git to auto-sign your commits:
     git config --global commit.gpgsign true
 
 The PGP public keys of the contributors can be found in contrib/contributors_gpg_keys. Please add your PGP key with your first pull request.
-
-

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,15 +5,15 @@ Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty32"
 
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
-    sudo locale-gen UTF-8 
+    sudo locale-gen UTF-8
     sudo add-apt-repository ppa:terry.guo/gcc-arm-embedded -y
     sudo apt-get update
     sudo apt-get install -y cmake git gcc-arm-none-eabi
   SHELL
-  
+
   config.vm.provision "shell", run: "always", privileged: false, inline: <<-SHELL
-    mkdir -p /vagrant/build
-    cd /vagrant/build
+    mkdir -p /vagrant/build-vagrant
+    cd /vagrant/build-vagrant
     rm -rf * && cmake .. -DBUILD_TYPE=firmware && make
   SHELL
 end


### PR DESCRIPTION
Just so it doesn't mess with the default build-path in the README.

Also, the currently build on my Arch gives some warning errors on libsecp256k1, maybe we should disable the cmake warnings for external libraries. Or fix it - if they want those changes upstream (might slow it down).