### PR TITLE
limit backup filename characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ version.h
 *.swp
 *.swo
 *.bak
+*.bin
 !*.c

--- a/src/commander.c
+++ b/src/commander.c
@@ -486,12 +486,17 @@ static void commander_process_seed(yajl_val json_node)
     }
 
     if (filename) {
+        commander_clear_report();
+
+        if (utils_limit_alphanumeric_hyphen_underscore_period(filename) != DBB_OK) {
+            commander_fill_report(cmd_str(CMD_seed), NULL, DBB_ERR_SD_BAD_CHAR);
+            return;
+        }
+
         if (sd_load(filename, CMD_seed)) {
-            commander_clear_report();
             commander_fill_report(cmd_str(CMD_seed), NULL, DBB_ERR_SD_OPEN_FILE);
             return;
         }
-        commander_clear_report();
     }
 
     char *src = malloc(strlens(source) + 1);

--- a/src/flags.h
+++ b/src/flags.h
@@ -223,6 +223,7 @@ X(ERR_SD_READ_FILE,    407, "Could not read the file.")\
 X(ERR_SD_ERASE,        408, "May not have erased all files (or no file present).")\
 X(ERR_SD_NUM_FILES,    409, "Too many files to read. The list is truncated.")\
 X(ERR_SD_NO_MATCH,     410, "Backup file does not match wallet.")\
+X(ERR_SD_BAD_CHAR,     411, "Filenames limited to alphanumeric values, hyphens, and underscores.")\
 X(ERR_MEM_ATAES,       500, "Chip communication error.")\
 X(ERR_MEM_FLASH,       501, "Could not read flash.")\
 X(ERR_MEM_ENCRYPT,     502, "Could not encrypt.")\

--- a/src/utils.c
+++ b/src/utils.c
@@ -45,6 +45,25 @@ void utils_clear_buffers(void)
 }
 
 
+uint8_t utils_limit_alphanumeric_hyphen_underscore_period(const char *str)
+{
+    static char characters[] =
+        ".-_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    size_t i;
+
+    if (!strlens(str)) {
+        return DBB_ERROR;
+    }
+
+    for (i = 0 ; i < strlens(str); i++) {
+        if (!strchr(characters, str[i])) {
+            return DBB_ERROR;
+        }
+    }
+    return DBB_OK;
+}
+
+
 uint8_t *utils_hex_to_uint8(const char *str)
 {
     if (strlens(str) > TO_UINT8_HEX_BUF_LEN) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -41,6 +41,7 @@
 
 
 void utils_clear_buffers(void);
+uint8_t utils_limit_alphanumeric_hyphen_underscore_period(const char *str);
 uint8_t *utils_hex_to_uint8(const char *str);
 char *utils_uint8_to_hex(const uint8_t *bin, size_t l);
 void utils_reverse_hex(char *h, int len);


### PR DESCRIPTION
Limit backup filename characters to be:
```
.-_abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
```