### PR TITLE
give warning when too many backup files to list

### DIFF
--- a/src/flags.h
+++ b/src/flags.h
@@ -61,7 +61,8 @@
 #define VERIFYPASS_CRYPT_TEST       "Digital Bitbox 2FA"
 #define AUTOBACKUP_FILENAME         "autobackup_"
 #define AUTOBACKUP_NUM              50
-#define AES_DATA_LEN_MAX            2048// base64 increases size by ~4/3; AES encryption by max 32 char
+#define SD_FILEBUF_LEN_MAX          (COMMANDER_REPORT_SIZE / 2)
+#define AES_DATA_LEN_MAX            (COMMANDER_REPORT_SIZE / 2)// base64 increases size by ~4/3; AES encryption by max 32 char
 #define PASSWORD_LEN_MIN            4
 
 
@@ -118,6 +119,7 @@ X(sham)           \
 X(input)          \
 X(ataes)          \
 X(touchbutton)    \
+X(warning)        \
 X(NUM)             /* keep last */
 
 
@@ -231,6 +233,7 @@ X(ERR_TOUCH_ABORT,     600, "Aborted by user.")\
 X(ERR_TOUCH_TIMEOUT,   601, "Touchbutton timed out.")\
 X(WARN_RESET,          900, "attempts remain before the device is reset.")\
 X(WARN_NO_MCU,         901, "Ignored for non-embedded testing.")\
+X(WARN_SD_NUM_FILES,   902, "Too many backup files to read. The list is truncated.")\
 X(FLAG_NUM,              0, 0)/* keep last */
 
 

--- a/src/sd.c
+++ b/src/sd.c
@@ -184,7 +184,7 @@ uint8_t sd_list(int cmd)
     fno.lfsize = sizeof(c_lfn);
 #endif
 
-    char files[1028] = {0};
+    char files[SD_FILEBUF_LEN_MAX] = {0};
     size_t f_len = 0;
     uint32_t pos = 1;
 
@@ -232,8 +232,9 @@ uint8_t sd_list(int cmd)
             f_len += strlen(pc_fn) + strlens(",\"\"");
             if (f_len + 1 >= sizeof(files)) {
                 f_mount(LUN_ID_SD_MMC_0_MEM, NULL);
-                commander_fill_report(cmd_str(cmd), NULL, DBB_ERR_SD_NUM_FILES);
-                goto err;
+                commander_fill_report(cmd_str(CMD_warning), flag_msg(DBB_WARN_SD_NUM_FILES), DBB_OK);
+                strcat(files, "\"]");
+                goto exit;
             }
 
             if (pos >= sd_listing_pos) {
@@ -250,6 +251,7 @@ uint8_t sd_list(int cmd)
         commander_fill_report(cmd_str(cmd), NULL, DBB_ERR_SD_OPEN_DIR);
     }
 
+exit:
     commander_fill_report(cmd_str(cmd), files, DBB_JSON_ARRAY);
 
     f_mount(LUN_ID_SD_MMC_0_MEM, NULL);


### PR DESCRIPTION
Returns truncated list of files (newest files dropped). The buffer limit for the list of files is 2048 characters.
```
{ "warning": "Too many files to read. The list is truncated.", "backup": ["file1","file2","file3", ... ]}
```

Previously an empty list was returned with an error message.