### PR TITLE
backups include device name concatenated to end of xpriv

### DIFF
--- a/src/flags.h
+++ b/src/flags.h
@@ -59,6 +59,7 @@
 #define COMMANDER_MAX_ATTEMPTS      15// max PASSWORD or LOCK PIN attempts before device reset
 #define VERIFYPASS_FILENAME         "verification.txt"
 #define VERIFYPASS_CRYPT_TEST       "Digital Bitbox 2FA"
+#define DEVICE_DEFAULT_NAME         "My Digital Bitbox"
 #define AUTOBACKUP_FILENAME         "autobackup_"
 #define AUTOBACKUP_NUM              50
 #define SD_FILEBUF_LEN_MAX          (COMMANDER_REPORT_SIZE / 2)

--- a/src/memory.c
+++ b/src/memory.c
@@ -253,7 +253,7 @@ void memory_erase(void)
     memory_write_aeskey((const char *)MEM_PAGE_ERASE, MEM_PAGE_LEN, PASSWORD_STAND_STRETCH);
     memory_write_aeskey((const char *)MEM_PAGE_ERASE, MEM_PAGE_LEN, PASSWORD_CRYPT);
     memory_erase_seed();
-    memory_name("Digital Bitbox");
+    memory_name(DEVICE_DEFAULT_NAME);
     memory_write_erased(DEFAULT_erased);
     memory_write_unlocked(DEFAULT_unlocked);
     memory_access_err_count(DBB_ACCESS_INITIALIZE);

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -62,6 +62,7 @@ static void tests_seed_xpub_backup(void)
         "{\"source\":\"xprv9s21ZrQH143K2MkmL8hdyZk5uwTPEqkwS72jXDt5DGRtUVrfYiAvAnGmxmP3J5Z3BG5uQcy5UYUMDsqisyXEDNCG2uzixsckhnfCrJxKVme\"}";
     char seed_xpriv_wrong_len[] =
         "{\"source\":\"xprv9s21ZrQH143K2MkmL8hdyZk5uwTPEqkwS72jXDt5DGRtUVrfYiAvAnGmxmP3J5Z3BG5uQcy5UYUMDsqisyXEDNCG2uzixsckhnfCrJxKVm\"}";
+    char name0[] = "name0";
 
     const char **cipher, **run;
     static const char *options[] = {
@@ -94,6 +95,11 @@ static void tests_seed_xpub_backup(void)
 
         api_format_send_cmd(cmd_str(CMD_password), tests_pwd, PASSWORD_NONE);
         u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+
+        // rename
+        api_format_send_cmd(cmd_str(CMD_name), name0, PASSWORD_STAND);
+        u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+        u_assert_str_eq(name0, api_read_value(CMD_name));
 
         memset(xpub0, 0, sizeof(xpub0));
         memset(xpub1, 0, sizeof(xpub1));
@@ -133,15 +139,22 @@ static void tests_seed_xpub_backup(void)
         api_format_send_cmd(cmd_str(CMD_backup), back, PASSWORD_STAND);
         u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
-        // erase
+        // erase device
         api_reset_device();
 
         api_format_send_cmd(cmd_str(CMD_password), tests_pwd, PASSWORD_NONE);
         u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
-        // load backup default
+        // check has default name
+        api_format_send_cmd(cmd_str(CMD_name), "", PASSWORD_STAND);
+        u_assert_str_eq(DEVICE_DEFAULT_NAME, api_read_value(CMD_name));
+
+        // load backup
         api_format_send_cmd(cmd_str(CMD_seed), seed_b, PASSWORD_STAND);
         u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+
+        api_format_send_cmd(cmd_str(CMD_name), "", PASSWORD_STAND);
+        u_assert_str_eq(name0, api_read_value(CMD_name));
 
         api_format_send_cmd(cmd_str(CMD_xpub), keypath, PASSWORD_STAND);
         u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));


### PR DESCRIPTION
Helps improve organizing wallets.

Backup looks like `<xpriv>-<name>`:
```
xprv9T4ue1W81ZrQH1NrG7c3qSMKYC2Rvu6LZNEAcfdJ443K33ZzZgdTVnzwmjEfy52tAcGq51eSG9s2K3oPWeCcfHzHdthnG3WjJAwtBS3akCG-My Digital Bitbox
```