### PR TITLE
Require encryption for backups, enter by api

### DIFF
--- a/src/flags.h
+++ b/src/flags.h
@@ -111,6 +111,7 @@ X(script)         \
 X(value)          \
 X(erase)          \
 X(check)          \
+X(key)            \
 X(sig)            \
 X(pin)            \
 /*  reply keys  */\
@@ -131,7 +132,6 @@ X(success)        \
 X(error)          \
 X(accept)         \
 X(aborted)        \
-X(yes)            \
 X(meta)           \
 X(list)           \
 X(sdcard)         \
@@ -228,6 +228,7 @@ X(ERR_SD_ERASE,        408, "May not have erased all files (or no file present).
 X(ERR_SD_NUM_FILES,    409, "Too many files to read. The list is truncated.")\
 X(ERR_SD_NO_MATCH,     410, "Backup file does not match wallet.")\
 X(ERR_SD_BAD_CHAR,     411, "Filenames limited to alphanumeric values, hyphens, and underscores.")\
+X(ERR_SD_KEY,          412, "Please provide an encryption key.")\
 X(ERR_MEM_ATAES,       500, "Chip communication error.")\
 X(ERR_MEM_FLASH,       501, "Could not read flash.")\
 X(ERR_MEM_ENCRYPT,     502, "Could not encrypt.")\

--- a/src/memory.c
+++ b/src/memory.c
@@ -53,7 +53,7 @@ __extension__ static uint8_t MEM_aeskey_stand[] = {[0 ... MEM_PAGE_LEN - 1] = 0x
 __extension__ static uint8_t MEM_aeskey_crypt[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
 __extension__ static uint8_t MEM_aeskey_verify[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
 __extension__ static uint8_t MEM_aeskey_memory[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
-__extension__ static uint8_t MEM_aeskey_stand_stretch[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
+__extension__ static uint8_t MEM_aeskey_stretch[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
 __extension__ static uint8_t MEM_master_chain[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
 __extension__ static uint8_t MEM_master[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
 __extension__ static uint8_t MEM_name[] = {[0 ... MEM_PAGE_LEN - 1] = '0'};
@@ -231,7 +231,6 @@ int memory_setup(void)
         memory_eeprom_crypt(NULL, MEM_aeskey_stand, MEM_AESKEY_STAND_ADDR);
         memory_eeprom_crypt(NULL, MEM_aeskey_crypt, MEM_AESKEY_CRYPT_ADDR);
         memory_eeprom_crypt(NULL, MEM_aeskey_verify, MEM_AESKEY_VERIFY_ADDR);
-        memory_eeprom_crypt(NULL, MEM_aeskey_stand_stretch, MEM_AESKEY_STAND_STRETCH_ADDR);
         memory_eeprom(NULL, &MEM_erased, MEM_ERASED_ADDR, 1);
     }
     return DBB_OK;
@@ -250,7 +249,7 @@ void memory_erase(void)
     memory_mempass();
     memory_create_verifypass();
     memory_write_aeskey((const char *)MEM_PAGE_ERASE, MEM_PAGE_LEN, PASSWORD_STAND);
-    memory_write_aeskey((const char *)MEM_PAGE_ERASE, MEM_PAGE_LEN, PASSWORD_STAND_STRETCH);
+    memory_write_aeskey((const char *)MEM_PAGE_ERASE, MEM_PAGE_LEN, PASSWORD_STRETCH);
     memory_write_aeskey((const char *)MEM_PAGE_ERASE, MEM_PAGE_LEN, PASSWORD_CRYPT);
     memory_erase_seed();
     memory_name(DEVICE_DEFAULT_NAME);
@@ -268,6 +267,7 @@ void memory_clear(void)
     // Do not clear for testing routines (i.e. not embedded).
     memcpy(MEM_master_chain, MEM_PAGE_ERASE, MEM_PAGE_LEN);
     memcpy(MEM_master, MEM_PAGE_ERASE, MEM_PAGE_LEN);
+    memcpy(MEM_aeskey_stretch, MEM_PAGE_ERASE, MEM_PAGE_LEN);
 #endif
 }
 
@@ -334,9 +334,9 @@ int memory_write_aeskey(const char *password, int len, PASSWORD_ID id)
         case PASSWORD_STAND:
             ret = memory_eeprom_crypt(password_b, MEM_aeskey_stand, MEM_AESKEY_STAND_ADDR);
             break;
-        case PASSWORD_STAND_STRETCH:
-            ret = memory_eeprom_crypt(password_b, MEM_aeskey_stand_stretch,
-                                      MEM_AESKEY_STAND_STRETCH_ADDR);
+        case PASSWORD_STRETCH:
+            memcpy(MEM_aeskey_stretch, password_b, MEM_PAGE_LEN);
+            ret = DBB_OK;
             break;
         case PASSWORD_CRYPT:
             ret = memory_eeprom_crypt(password_b, MEM_aeskey_crypt, MEM_AESKEY_CRYPT_ADDR);
@@ -365,8 +365,8 @@ uint8_t *memory_report_aeskey(PASSWORD_ID id)
             return MEM_aeskey_memory;
         case PASSWORD_STAND:
             return MEM_aeskey_stand;
-        case PASSWORD_STAND_STRETCH:
-            return MEM_aeskey_stand_stretch;
+        case PASSWORD_STRETCH:
+            return MEM_aeskey_stretch;
         case PASSWORD_CRYPT:
             return MEM_aeskey_crypt;
         case PASSWORD_VERIFY:

--- a/src/memory.h
+++ b/src/memory.h
@@ -45,7 +45,6 @@
 #define MEM_AESKEY_STAND_ADDR           0x0400// Zone 4
 #define MEM_AESKEY_VERIFY_ADDR          0x0500// Zone 5
 #define MEM_AESKEY_CRYPT_ADDR           0x0600// Zone 6
-#define MEM_AESKEY_STAND_STRETCH_ADDR   0x0700// Zone 7
 
 // Default settings
 #define DEFAULT_unlocked  0xFF
@@ -55,7 +54,7 @@
 
 typedef enum PASSWORD_ID {
     PASSWORD_STAND,
-    PASSWORD_STAND_STRETCH, /* for backups */
+    PASSWORD_STRETCH, /* for backups */
     PASSWORD_VERIFY,
     PASSWORD_MEMORY,
     PASSWORD_CRYPT,

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -61,9 +61,9 @@ static void tests_seed_xpub_backup(void)
     char seed_create_bad[] =
         "{\"source\":\"create\", \"filename\":\"../seed_create_bad.bak\", \"key\":\"password\"}";
     char seed_xpriv[] =
-        "{\"source\":\"xprv9s21ZrQH143K2MkmL8hdyZk5uwTPEqkwS72jXDt5DGRtUVrfYiAvAnGmxmP3J5Z3BG5uQcy5UYUMDsqisyXEDNCG2uzixsckhnfCrJxKVme\", \"key\":\"password\"}";
+        "{\"source\":\"xprv9s21ZrQH143K2MkmL8hdyZk5uwTPEqkwS72jXDt5DGRtUVrfYiAvAnGmxmP3J5Z3BG5uQcy5UYUMDsqisyXEDNCG2uzixsckhnfCrJxKVme\"}";
     char seed_xpriv_wrong_len[] =
-        "{\"source\":\"xprv9s21ZrQH143K2MkmL8hdyZk5uwTPEqkwS72jXDt5DGRtUVrfYiAvAnGmxmP3J5Z3BG5uQcy5UYUMDsqisyXEDNCG2uzixsckhnfCrJxKVm\", \"key\":\"password\"}";
+        "{\"source\":\"xprv9s21ZrQH143K2MkmL8hdyZk5uwTPEqkwS72jXDt5DGRtUVrfYiAvAnGmxmP3J5Z3BG5uQcy5UYUMDsqisyXEDNCG2uzixsckhnfCrJxKVm\"}";
 
     snprintf(seed_c, sizeof(seed_c),
              "{\"source\":\"%s\", \"filename\":\"%s\", \"key\":\"%s\"}", attr_str(ATTR_create),
@@ -928,7 +928,7 @@ static void tests_sign(void)
 
     // seed
     char seed[] =
-        "{\"source\":\"xprv9s21ZrQH143K3URucR3Zd2rRJBGGQsNFEo3Ld3JtTeUAQARegm573eJiNsAjGsyAj3h9roseS7GA7Y3dcub1pLpQD3eud2XzkoCoFpYBLF3\", \"filename\":\"s.bak\", \"key\":\"password\"}";
+        "{\"source\":\"xprv9s21ZrQH143K3URucR3Zd2rRJBGGQsNFEo3Ld3JtTeUAQARegm573eJiNsAjGsyAj3h9roseS7GA7Y3dcub1pLpQD3eud2XzkoCoFpYBLF3\", \"filename\":\"s.bak\"}";
     api_format_send_cmd(cmd_str(CMD_seed), seed, PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
@@ -1146,7 +1146,7 @@ static void tests_aes_cbc(void)
     };
 
     char seed[] =
-        "{\"source\":\"xprv9s21ZrQH143K2MkmL8hdyZk5uwTPEqkwS72jXDt5DGRtUVrfYiAvAnGmxmP3J5Z3BG5uQcy5UYUMDsqisyXEDNCG2uzixsckhnfCrJxKVme\", \"filename\":\"x.bak\", \"key\":\"password\"}";
+        "{\"source\":\"xprv9s21ZrQH143K2MkmL8hdyZk5uwTPEqkwS72jXDt5DGRtUVrfYiAvAnGmxmP3J5Z3BG5uQcy5UYUMDsqisyXEDNCG2uzixsckhnfCrJxKVme\", \"filename\":\"x.bak\"}";
 
     api_reset_device();
 
@@ -1252,7 +1252,6 @@ static void tests_aes_cbc(void)
 
 static void run_utests(void)
 {
-    u_run_test(tests_seed_xpub_backup);
     u_run_test(tests_echo_tfa);
     u_run_test(tests_aes_cbc);
     u_run_test(tests_name);
@@ -1261,6 +1260,7 @@ static void run_utests(void)
     u_run_test(tests_sign);
     u_run_test(tests_device);
     u_run_test(tests_input);
+    u_run_test(tests_seed_xpub_backup);
 
     if (!U_TESTS_FAIL) {
         printf("\nALL %i TESTS PASSED\n\n", U_TESTS_RUN);

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -46,6 +46,8 @@ int U_TESTS_FAIL = 0;
 
 static void tests_seed_xpub_backup(void)
 {
+    char name0[] = "name0";
+    char key[] = "password";
     char xpub0[112], xpub1[112], *echo;
     char seed_c[512], seed_b[512], back[512], check[512], erase_file[512];
     char filename[] = "tests_backup.txt";
@@ -53,142 +55,125 @@ static void tests_seed_xpub_backup(void)
     char filename_bad[] = "tests_backup_bad<.txt";
     char keypath[] = "m/44\'/0\'/";
     char seed_create[] =
-        "{\"source\":\"create\", \"filename\":\"seed_create.bak\"}";
+        "{\"source\":\"create\", \"filename\":\"seed_create.bak\", \"key\":\"password\"}";
     char seed_create_2[] =
-        "{\"source\":\"create\", \"filename\":\"seed_create_2.bak\"}";
+        "{\"source\":\"create\", \"filename\":\"seed_create_2.bak\", \"key\":\"password\"}";
     char seed_create_bad[] =
-        "{\"source\":\"create\", \"filename\":\"../seed_create_bad.bak\"}";
+        "{\"source\":\"create\", \"filename\":\"../seed_create_bad.bak\", \"key\":\"password\"}";
     char seed_xpriv[] =
-        "{\"source\":\"xprv9s21ZrQH143K2MkmL8hdyZk5uwTPEqkwS72jXDt5DGRtUVrfYiAvAnGmxmP3J5Z3BG5uQcy5UYUMDsqisyXEDNCG2uzixsckhnfCrJxKVme\"}";
+        "{\"source\":\"xprv9s21ZrQH143K2MkmL8hdyZk5uwTPEqkwS72jXDt5DGRtUVrfYiAvAnGmxmP3J5Z3BG5uQcy5UYUMDsqisyXEDNCG2uzixsckhnfCrJxKVme\", \"key\":\"password\"}";
     char seed_xpriv_wrong_len[] =
-        "{\"source\":\"xprv9s21ZrQH143K2MkmL8hdyZk5uwTPEqkwS72jXDt5DGRtUVrfYiAvAnGmxmP3J5Z3BG5uQcy5UYUMDsqisyXEDNCG2uzixsckhnfCrJxKVm\"}";
-    char name0[] = "name0";
+        "{\"source\":\"xprv9s21ZrQH143K2MkmL8hdyZk5uwTPEqkwS72jXDt5DGRtUVrfYiAvAnGmxmP3J5Z3BG5uQcy5UYUMDsqisyXEDNCG2uzixsckhnfCrJxKVm\", \"key\":\"password\"}";
 
-    const char **cipher, **run;
-    static const char *options[] = {
-        // run  encrypt
-        "y",    NULL,
-        "y",    "no",
-        "y",    "yes",
-        NULL,   NULL,
-    };
-    run = options;
-    cipher = options + 1;
+    snprintf(seed_c, sizeof(seed_c),
+             "{\"source\":\"%s\", \"filename\":\"%s\", \"key\":\"%s\"}", attr_str(ATTR_create),
+             filename_create, key);
+    snprintf(seed_b, sizeof(seed_b), "{\"source\":\"%s\",\"key\":\"%s\"}", filename, key);
+    snprintf(back, sizeof(back), "{\"filename\":\"%s\",\"key\":\"%s\"}", filename, key);
+    snprintf(check, sizeof(check), "{\"check\":\"%s\",\"key\":\"%s\"}", filename, key);
 
-    while (*run) {
-        memset(seed_c, 0, sizeof(seed_c));
-        memset(seed_b, 0, sizeof(seed_b));
-        memset(back, 0, sizeof(back));
-        memset(check, 0, sizeof(check));
+    // erase
+    api_reset_device();
 
-        snprintf(seed_c, sizeof(seed_c), "{\"source\":\"%s\", \"filename\":\"%s\"}",
-                 attr_str(ATTR_create), filename_create);
-        snprintf(seed_b, sizeof(seed_b), "{\"source\":\"%s\",\"decrypt\":\"%s\"}", filename,
-                 *cipher);
-        snprintf(back, sizeof(back), "{\"filename\":\"%s\",\"encrypt\":\"%s\"}", filename,
-                 *cipher);
-        snprintf(check, sizeof(check), "{\"check\":\"%s\",\"decrypt\":\"%s\"}", filename,
-                 *cipher);
+    api_format_send_cmd(cmd_str(CMD_password), tests_pwd, PASSWORD_NONE);
+    u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
-        // erase
-        api_reset_device();
+    // rename
+    api_format_send_cmd(cmd_str(CMD_name), name0, PASSWORD_STAND);
+    u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+    u_assert_str_eq(name0, api_read_value(CMD_name));
 
-        api_format_send_cmd(cmd_str(CMD_password), tests_pwd, PASSWORD_NONE);
-        u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+    memset(xpub0, 0, sizeof(xpub0));
+    memset(xpub1, 0, sizeof(xpub1));
+    api_format_send_cmd(cmd_str(CMD_backup), back, PASSWORD_STAND);
+    u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_KEY_MASTER));
 
-        // rename
-        api_format_send_cmd(cmd_str(CMD_name), name0, PASSWORD_STAND);
-        u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
-        u_assert_str_eq(name0, api_read_value(CMD_name));
+    // create
+    api_format_send_cmd(cmd_str(CMD_xpub), keypath, PASSWORD_STAND);
+    u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_KEY_CHILD));
 
-        memset(xpub0, 0, sizeof(xpub0));
-        memset(xpub1, 0, sizeof(xpub1));
-        api_format_send_cmd(cmd_str(CMD_backup), back, PASSWORD_STAND);
-        u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_KEY_MASTER));
+    api_format_send_cmd(cmd_str(CMD_seed), seed_c, PASSWORD_STAND);
+    u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
-        // create
-        api_format_send_cmd(cmd_str(CMD_xpub), keypath, PASSWORD_STAND);
-        u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_KEY_CHILD));
+    api_format_send_cmd(cmd_str(CMD_xpub), keypath, PASSWORD_STAND);
+    u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
-        api_format_send_cmd(cmd_str(CMD_seed), seed_c, PASSWORD_STAND);
-        u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+    memcpy(xpub0, api_read_value(CMD_xpub), sizeof(xpub0));
+    u_assert_str_not_eq(xpub0, xpub1);
 
-        api_format_send_cmd(cmd_str(CMD_xpub), keypath, PASSWORD_STAND);
-        u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
-
-        memcpy(xpub0, api_read_value(CMD_xpub), sizeof(xpub0));
-        u_assert_str_not_eq(xpub0, xpub1);
-
-        if (!TEST_LIVE_DEVICE) {
-            echo = api_read_value_decrypt(CMD_echo, PASSWORD_VERIFY);
-            u_assert_str_eq(xpub0, echo);
-        }
-
-        // check backup list and erase
-        api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), PASSWORD_STAND);
-        u_assert_str_has(utils_read_decrypted_report(), filename_create);
-
-        // backup
-        api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), PASSWORD_STAND);
-        u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
-        u_assert_str_has_not(utils_read_decrypted_report(), filename_create);
-        if (TEST_LIVE_DEVICE) {
-            u_assert_str_has_not(utils_read_decrypted_report(), flag_msg(DBB_ERR_SD_ERASE));
-        }
-
-        api_format_send_cmd(cmd_str(CMD_backup), back, PASSWORD_STAND);
-        u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
-
-        // erase device
-        api_reset_device();
-
-        api_format_send_cmd(cmd_str(CMD_password), tests_pwd, PASSWORD_NONE);
-        u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
-
-        // check has default name
-        api_format_send_cmd(cmd_str(CMD_name), "", PASSWORD_STAND);
-        u_assert_str_eq(DEVICE_DEFAULT_NAME, api_read_value(CMD_name));
-
-        // load backup
-        api_format_send_cmd(cmd_str(CMD_seed), seed_b, PASSWORD_STAND);
-        u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
-
-        api_format_send_cmd(cmd_str(CMD_name), "", PASSWORD_STAND);
-        u_assert_str_eq(name0, api_read_value(CMD_name));
-
-        api_format_send_cmd(cmd_str(CMD_xpub), keypath, PASSWORD_STAND);
-        u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
-
-        memcpy(xpub1, api_read_value(CMD_xpub), sizeof(xpub1));
-        if (!TEST_LIVE_DEVICE) {
-            echo = api_read_value_decrypt(CMD_echo, PASSWORD_VERIFY);
-            u_assert_str_eq(xpub0, echo);
-        }
-
-        // check xpubs
-        u_assert_str_eq(xpub0, xpub1);
-
-        // check backup list and erase
-        api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), PASSWORD_STAND);
-        u_assert_str_has(utils_read_decrypted_report(), filename);
-        u_assert_str_has_not(utils_read_decrypted_report(), filename_create);
-
-        api_format_send_cmd(cmd_str(CMD_backup), check, PASSWORD_STAND);
-        u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_success));
-
-        api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), PASSWORD_STAND);
-        u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
-
-        api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), PASSWORD_STAND);
-        u_assert_str_has_not(utils_read_decrypted_report(), filename);
-        u_assert_str_has_not(utils_read_decrypted_report(), filename_create);
-
-        api_format_send_cmd(cmd_str(CMD_backup), check, PASSWORD_STAND);
-        u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_success));
-
-        run += 2;
-        cipher += 2;
+    if (!TEST_LIVE_DEVICE) {
+        echo = api_read_value_decrypt(CMD_echo, PASSWORD_VERIFY);
+        u_assert_str_eq(xpub0, echo);
     }
+
+    // check backup list and erase
+    api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), PASSWORD_STAND);
+    u_assert_str_has(utils_read_decrypted_report(), filename_create);
+
+    // backup
+    api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), PASSWORD_STAND);
+    u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+    u_assert_str_has_not(utils_read_decrypted_report(), filename_create);
+    if (TEST_LIVE_DEVICE) {
+        u_assert_str_has_not(utils_read_decrypted_report(), flag_msg(DBB_ERR_SD_ERASE));
+    }
+
+    api_format_send_cmd(cmd_str(CMD_backup), back, PASSWORD_STAND);
+    u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+
+    // erase device
+    api_reset_device();
+
+    api_format_send_cmd(cmd_str(CMD_password), tests_pwd, PASSWORD_NONE);
+    u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+
+    // check has default name
+    api_format_send_cmd(cmd_str(CMD_name), "", PASSWORD_STAND);
+    u_assert_str_eq(DEVICE_DEFAULT_NAME, api_read_value(CMD_name));
+
+    // load backup
+    api_format_send_cmd(cmd_str(CMD_seed), seed_b, PASSWORD_STAND);
+    u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+
+    api_format_send_cmd(cmd_str(CMD_name), "", PASSWORD_STAND);
+    u_assert_str_eq(name0, api_read_value(CMD_name));
+
+    api_format_send_cmd(cmd_str(CMD_xpub), keypath, PASSWORD_STAND);
+    u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+
+    memcpy(xpub1, api_read_value(CMD_xpub), sizeof(xpub1));
+    if (!TEST_LIVE_DEVICE) {
+        echo = api_read_value_decrypt(CMD_echo, PASSWORD_VERIFY);
+        u_assert_str_eq(xpub0, echo);
+    }
+
+    // check xpubs
+    u_assert_str_eq(xpub0, xpub1);
+
+    // check backup list and erase
+    api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), PASSWORD_STAND);
+    u_assert_str_has(utils_read_decrypted_report(), filename);
+    u_assert_str_has_not(utils_read_decrypted_report(), filename_create);
+
+    api_format_send_cmd(cmd_str(CMD_backup), check, PASSWORD_STAND);
+    u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_success));
+
+    api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), PASSWORD_STAND);
+    u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+
+    api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), PASSWORD_STAND);
+    u_assert_str_has_not(utils_read_decrypted_report(), filename);
+    u_assert_str_has_not(utils_read_decrypted_report(), filename_create);
+
+    api_format_send_cmd(cmd_str(CMD_backup), check, PASSWORD_STAND);
+    u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_success));
+
+
+
+
+
+
+
 
     api_reset_device();
 
@@ -222,7 +207,7 @@ static void tests_seed_xpub_backup(void)
 
         for (i = 0; i < SD_FILEBUF_LEN_MAX / sizeof(long_backup_name); i++) {
             snprintf(lbn, sizeof(lbn), "%lu%s", i, long_backup_name);
-            snprintf(back, sizeof(back), "{\"filename\":\"%s\"}", lbn);
+            snprintf(back, sizeof(back), "{\"filename\":\"%s\", \"key\":\"password\"}", lbn);
             api_format_send_cmd(cmd_str(CMD_backup), back, PASSWORD_STAND);
             u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
@@ -231,7 +216,7 @@ static void tests_seed_xpub_backup(void)
         }
 
         snprintf(lbn, sizeof(lbn), "%lu%s", i, long_backup_name);
-        snprintf(back, sizeof(back), "{\"filename\":\"%s\"}", lbn);
+        snprintf(back, sizeof(back), "{\"filename\":\"%s\", \"key\":\"password\"}", lbn);
         api_format_send_cmd(cmd_str(CMD_backup), back, PASSWORD_STAND);
         u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
@@ -280,21 +265,21 @@ static void tests_seed_xpub_backup(void)
     u_assert_str_has_not(utils_read_decrypted_report(), filename);
 
     if (TEST_LIVE_DEVICE) {
-        snprintf(back, sizeof(back), "{\"filename\":\"%s\"}", filename_bad);
+        snprintf(back, sizeof(back), "{\"filename\":\"%s\", \"key\":\"password\"}", filename_bad);
         api_format_send_cmd(cmd_str(CMD_backup), back, PASSWORD_STAND);
         u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_SD_BAD_CHAR));
 
-        snprintf(check, sizeof(check), "{\"check\":\"%s\"}", filename_bad);
+        snprintf(check, sizeof(check), "{\"check\":\"%s\", \"key\":\"password\"}", filename_bad);
         api_format_send_cmd(cmd_str(CMD_backup), check, PASSWORD_STAND);
         u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_success));
         u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_SD_BAD_CHAR));
     }
 
-    snprintf(back, sizeof(back), "{\"filename\":\"%s\"}", filename);
+    snprintf(back, sizeof(back), "{\"filename\":\"%s\", \"key\":\"password\"}", filename);
     api_format_send_cmd(cmd_str(CMD_backup), back, PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
-    snprintf(check, sizeof(check), "{\"check\":\"%s\"}", filename);
+    snprintf(check, sizeof(check), "{\"check\":\"%s\", \"key\":\"password\"}", filename);
     api_format_send_cmd(cmd_str(CMD_backup), check, PASSWORD_STAND);
     u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_success));
 
@@ -458,6 +443,9 @@ static void tests_device(void)
     api_format_send_cmd(cmd_str(CMD_seed), "", PASSWORD_STAND);
     u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_IO_INVALID_CMD));
 
+    api_format_send_cmd(cmd_str(CMD_seed), "{\"source\":\"create\"}", PASSWORD_STAND);
+    u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_SD_KEY));
+
     api_format_send_cmd(cmd_str(CMD_xpub), "", PASSWORD_STAND);
     u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_IO_INVALID_CMD));
 
@@ -465,7 +453,13 @@ static void tests_device(void)
     u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_IO_INVALID_CMD));
 
     api_format_send_cmd(cmd_str(CMD_backup), "", PASSWORD_STAND);
+    u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_SD_KEY));
+
+    api_format_send_cmd(cmd_str(CMD_backup), "{\"key\":\"password\"}", PASSWORD_STAND);
     u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_IO_INVALID_CMD));
+
+    api_format_send_cmd(cmd_str(CMD_backup), "{\"filename\":\"b.txt\"}", PASSWORD_STAND);
+    u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_SD_KEY));
 
     api_format_send_cmd(cmd_str(CMD_random), "", PASSWORD_STAND);
     u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_IO_INVALID_CMD));
@@ -486,33 +480,36 @@ static void tests_device(void)
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
-    api_format_send_cmd(cmd_str(CMD_seed), "{\"source\":\"create\"}", PASSWORD_STAND);
+    api_format_send_cmd(cmd_str(CMD_seed), "{\"source\":\"create\", \"key\":\"password\"}",
+                        PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), PASSWORD_STAND);
     u_assert_str_has(utils_read_decrypted_report(), AUTOBACKUP_FILENAME);
 
-    api_format_send_cmd(cmd_str(CMD_seed), "{\"source\":\"create\", \"filename\":\"c.bak\"}",
-                        PASSWORD_STAND);
+    api_format_send_cmd(cmd_str(CMD_seed),
+                        "{\"source\":\"create\", \"filename\":\"c.bak\", \"key\":\"password\"}", PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
     api_format_send_cmd(cmd_str(CMD_verifypass), attr_str(ATTR_create), PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
-    api_format_send_cmd(cmd_str(CMD_backup), "{\"filename\":\"b.txt\"}", PASSWORD_STAND);
+    api_format_send_cmd(cmd_str(CMD_backup), "{\"filename\":\"b.txt\", \"key\":\"password\"}",
+                        PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
     api_format_send_cmd(cmd_str(CMD_device), attr_str(ATTR_lock), PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
-    api_format_send_cmd(cmd_str(CMD_seed), "{\"source\":\"create\", \"filename\":\"l.bak\"}",
-                        PASSWORD_STAND);
+    api_format_send_cmd(cmd_str(CMD_seed),
+                        "{\"source\":\"create\", \"filename\":\"l.bak\", \"key\":\"password\"}", PASSWORD_STAND);
     u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_IO_LOCKED));
 
     api_format_send_cmd(cmd_str(CMD_verifypass), attr_str(ATTR_create), PASSWORD_STAND);
     u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_IO_LOCKED));
 
-    api_format_send_cmd(cmd_str(CMD_backup), "{\"filename\":\"b.txt\"}", PASSWORD_STAND);
+    api_format_send_cmd(cmd_str(CMD_backup), "{\"filename\":\"b.txt\", \"key\":\"password\"}",
+                        PASSWORD_STAND);
     u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_IO_LOCKED));
 
     api_format_send_cmd("invalid_cmd", "invalid_cmd", PASSWORD_STAND);
@@ -743,8 +740,8 @@ static void tests_echo_tfa(void)
     api_format_send_cmd(cmd_str(CMD_device), attr_str(ATTR_lock), PASSWORD_STAND);
     u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_KEY_MASTER));
 
-    api_format_send_cmd(cmd_str(CMD_seed), "{\"source\":\"create\", \"filename\":\"c.bak\"}",
-                        PASSWORD_STAND);
+    api_format_send_cmd(cmd_str(CMD_seed),
+                        "{\"source\":\"create\", \"filename\":\"c.bak\", \"key\":\"password\"}", PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
     // test verifypass
@@ -825,7 +822,8 @@ static void tests_echo_tfa(void)
         u_assert_str_has(utils_read_decrypted_report(), cmd_str(CMD_sig));
     }
 
-    api_format_send_cmd(cmd_str(CMD_seed), "{\"source\":\"create\"}", PASSWORD_STAND);
+    api_format_send_cmd(cmd_str(CMD_seed), "{\"source\":\"create\", \"key\":\"password\"}",
+                        PASSWORD_STAND);
     u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_IO_LOCKED));
 
     api_format_send_cmd(cmd_str(CMD_verifypass), attr_str(ATTR_export), PASSWORD_STAND);
@@ -930,7 +928,7 @@ static void tests_sign(void)
 
     // seed
     char seed[] =
-        "{\"source\":\"xprv9s21ZrQH143K3URucR3Zd2rRJBGGQsNFEo3Ld3JtTeUAQARegm573eJiNsAjGsyAj3h9roseS7GA7Y3dcub1pLpQD3eud2XzkoCoFpYBLF3\", \"filename\":\"s.bak\"}";
+        "{\"source\":\"xprv9s21ZrQH143K3URucR3Zd2rRJBGGQsNFEo3Ld3JtTeUAQARegm573eJiNsAjGsyAj3h9roseS7GA7Y3dcub1pLpQD3eud2XzkoCoFpYBLF3\", \"filename\":\"s.bak\", \"key\":\"password\"}";
     api_format_send_cmd(cmd_str(CMD_seed), seed, PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
@@ -1148,7 +1146,7 @@ static void tests_aes_cbc(void)
     };
 
     char seed[] =
-        "{\"source\":\"xprv9s21ZrQH143K2MkmL8hdyZk5uwTPEqkwS72jXDt5DGRtUVrfYiAvAnGmxmP3J5Z3BG5uQcy5UYUMDsqisyXEDNCG2uzixsckhnfCrJxKVme\", \"filename\":\"x.bak\"}";
+        "{\"source\":\"xprv9s21ZrQH143K2MkmL8hdyZk5uwTPEqkwS72jXDt5DGRtUVrfYiAvAnGmxmP3J5Z3BG5uQcy5UYUMDsqisyXEDNCG2uzixsckhnfCrJxKVme\", \"filename\":\"x.bak\", \"key\":\"password\"}";
 
     api_reset_device();
 
@@ -1254,6 +1252,7 @@ static void tests_aes_cbc(void)
 
 static void run_utests(void)
 {
+    u_run_test(tests_seed_xpub_backup);
     u_run_test(tests_echo_tfa);
     u_run_test(tests_aes_cbc);
     u_run_test(tests_name);
@@ -1262,7 +1261,6 @@ static void run_utests(void)
     u_run_test(tests_sign);
     u_run_test(tests_device);
     u_run_test(tests_input);
-    u_run_test(tests_seed_xpub_backup);
 
     if (!U_TESTS_FAIL) {
         printf("\nALL %i TESTS PASSED\n\n", U_TESTS_RUN);


### PR DESCRIPTION
THIS BREAKS API 
(seed and backup commands)

Now requires encryption passphrase for backups always. This separates device password from backup password. A client is recommended to strengthen the passphrase before sending. Note that, as a failsafe against naive clients, the MCU will still key stretch, salt, and hash the input key, but only 2048 rounds of PBKDF2 due to limited MCU resources. 

The seed command is now:
```
"seed" : 
{
      "source" : "source",
      "key" : "passphrase",
      "filename" : "filename"
}
```

Affected backup commands are now...
For creating a backup:
```
"backup" : 
{
      "key" : "passphrase",
      "filename" : "filename"
}
```

For checking if a backup file matches what is seeded in the wallet:
```
"backup" : 
{
      "key" : "passphrase",
      "check" : "filename"
}
```

The API BREAK is that `key` replaces `encrypt` or `decrypt` values and is a REQUIRED input.