### PR TITLE
use pdf format for backups

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -518,7 +518,7 @@ static void commander_process_seed(yajl_val json_node)
             return;
         }
 
-        if (sd_load(filename, CMD_seed)) {
+        if (sd_file_exists(filename) == DBB_OK) {
             commander_fill_report(cmd_str(CMD_seed), NULL, DBB_ERR_SD_OPEN_FILE);
             return;
         }
@@ -550,7 +550,7 @@ static void commander_process_seed(yajl_val json_node)
         int flen = strlens(AUTOBACKUP_FILENAME) + 8;
         char file[flen];
 
-        if (sd_present() != DBB_OK) {
+        if (sd_card_inserted() != DBB_OK) {
             commander_clear_report();
             commander_fill_report(cmd_str(CMD_seed), NULL, DBB_ERR_SEED_SD);
             goto exit;
@@ -565,8 +565,8 @@ static void commander_process_seed(yajl_val json_node)
                     goto exit;
                 }
                 memset(file, 0, sizeof(file));
-                snprintf(file, sizeof(file), "%s%i.bak", AUTOBACKUP_FILENAME, count++);
-            } while (sd_load(file, CMD_seed));
+                snprintf(file, sizeof(file), "%s%i.pdf", AUTOBACKUP_FILENAME, count++);
+            } while (sd_file_exists(file) == DBB_OK);
             filename = file;
         }
 
@@ -973,7 +973,7 @@ static void commander_process_device(yajl_val json_node)
             snprintf(bootlock, sizeof(bootlock), "%s", attr_str(ATTR_true));
         }
 
-        if (sd_present() == DBB_OK) {
+        if (sd_card_inserted() == DBB_OK) {
             snprintf(sdcard, sizeof(sdcard), "%s", attr_str(ATTR_true));
         } else {
             snprintf(sdcard, sizeof(sdcard), "%s", attr_str(ATTR_false));

--- a/src/sd.h
+++ b/src/sd.h
@@ -32,11 +32,28 @@
 #include <stdint.h>
 
 
+#define SD_PDF_LINE_BUF_SIZE 64
+#define SD_PDF_HEAD "%%PDF-1.1\n%%\xDB\xDC\xDD\xDE\xDF\n"
+#define SD_PDF_1_0  "1 0 obj\n<</Type /Catalog\n/Pages 2 0 R\n>>\nendobj\n"
+#define SD_PDF_2_0  "2 0 obj\n<</Type /Pages\n/Kids [3 0 R]\n/Count 1\n/MediaBox [0 0 595 842]\n>>\nendobj\n"
+#define SD_PDF_3_0  "3 0 obj\n<</Type /Page\n/Parent 2 0 R\n/Resources\n<</Font\n<</F1\n<</Type /Font\n/BaseFont /Helvetica\n/Subtype /Type1\n>>\n>>\n>>\n/Contents 4 0 R\n>>\nendobj\n"
+#define SD_PDF_4_0_HEAD  "4 0 obj\n<< /Length %i >>\nstream\n"
+#define SD_PDF_BACKUP_START "<20 2020202020> Tj"
+#define SD_PDF_BACKUP_END "<2020202020 20> Tj"
+#define SD_PDF_TEXT_START "BT\n/F1 12 Tf\n50 700 Td\n(Encrypted wallet backup:) Tj\n" SD_PDF_BACKUP_START "\n0 -40 Td\n("
+#define SD_PDF_TEXT_CONTINUE ") Tj\n0 -16 Td\n("
+#define SD_PDF_TEXT_END ") Tj\n" SD_PDF_BACKUP_END "\n0 -60 Td\n(Password:  ______________________) Tj\nET\n/F1 10 Tf\n0 -60 Td\n(Wallet format: BIP32 master extended private key (key path 'm/')) Tj\n0 -14 Td\n(Encryption algorithm: AES-256-CBC) Tj\n0 -14 Td\n(Password hardening: PBKDF2) Tj\n0 -24 Td\n(digitalbitbox.com/backup) Tj\n"
+#define SD_PDF_4_0_END "\nendstream\nendobj\n"
+#define SD_PDF_END  "xref\n0 5\n0000000000 65535 f \n%010i 00000 n \n%010i 00000 n \n%010i 00000 n \n%010i 00000 n \ntrailer\n<<\n/Size 5\n/Root 1 0 R\n>>\nstartxref\n%i\n%%%%%%%%EOF"
+
+
 uint8_t sd_list(int cmd);
-uint8_t sd_present(void);
+uint8_t sd_card_inserted(void);
+uint8_t sd_file_exists(const char *fn);
 uint8_t sd_erase(int cmd, const char *fn);
 char *sd_load(const char *fn, int cmd);
 uint8_t sd_write(const char *fn, const char *text, uint16_t t_len,
                  uint8_t replace, int cmd);
+
 
 #endif

--- a/src/sham.c
+++ b/src/sham.c
@@ -80,10 +80,21 @@ uint8_t sd_list(int cmd)
 }
 
 
-uint8_t sd_present(void)
+uint8_t sd_card_inserted(void)
 {
     commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
     return DBB_OK;
+}
+
+
+uint8_t sd_file_exists(const char *fn)
+{
+    (void) fn;
+    commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
+    if (!strncmp(sd_filename, fn, strlens(fn))) {
+        return DBB_OK;
+    }
+    return DBB_ERROR;
 }
 
 

--- a/src/sham.h
+++ b/src/sham.h
@@ -33,11 +33,12 @@
 
 
 void delay_ms(int delay);
+char *sd_load(const char *f, int cmd);
 uint8_t sd_write(const char *f, const char *t, uint16_t t_len,
                  uint8_t replace, int cmd);
-char *sd_load(const char *f, int cmd);
 uint8_t sd_list(int cmd);
-uint8_t sd_present(void);
+uint8_t sd_card_inserted(void);
+uint8_t sd_file_exists(const char *fn);
 uint8_t sd_erase(int cmd, const char *fn);
 uint8_t touch_button_press(uint8_t touch_type);
 uint8_t flash_read_unique_id(uint32_t *serial, uint32_t len);

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -55,11 +55,11 @@ static void tests_seed_xpub_backup(void)
     char filename_bad[] = "tests_backup_bad<.txt";
     char keypath[] = "m/44\'/0\'/";
     char seed_create[] =
-        "{\"source\":\"create\", \"filename\":\"seed_create.bak\", \"key\":\"password\"}";
+        "{\"source\":\"create\", \"filename\":\"seed_create.pdf\", \"key\":\"password\"}";
     char seed_create_2[] =
-        "{\"source\":\"create\", \"filename\":\"seed_create_2.bak\", \"key\":\"password\"}";
+        "{\"source\":\"create\", \"filename\":\"seed_create_2.pdf\", \"key\":\"password\"}";
     char seed_create_bad[] =
-        "{\"source\":\"create\", \"filename\":\"../seed_create_bad.bak\", \"key\":\"password\"}";
+        "{\"source\":\"create\", \"filename\":\"../seed_create_bad.pdf\", \"key\":\"password\"}";
     char seed_xpriv[] =
         "{\"source\":\"xprv9s21ZrQH143K2MkmL8hdyZk5uwTPEqkwS72jXDt5DGRtUVrfYiAvAnGmxmP3J5Z3BG5uQcy5UYUMDsqisyXEDNCG2uzixsckhnfCrJxKVme\"}";
     char seed_xpriv_wrong_len[] =
@@ -187,14 +187,14 @@ static void tests_seed_xpub_backup(void)
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), PASSWORD_STAND);
-    u_assert_str_has(utils_read_decrypted_report(), "seed_create.bak");
+    u_assert_str_has(utils_read_decrypted_report(), "seed_create.pdf");
 
     if (TEST_LIVE_DEVICE) {
         api_format_send_cmd(cmd_str(CMD_seed), seed_create_bad, PASSWORD_STAND);
         u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_SD_BAD_CHAR));
 
         api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), PASSWORD_STAND);
-        u_assert_str_has_not(utils_read_decrypted_report(), "../seed_create_bad.bak");
+        u_assert_str_has_not(utils_read_decrypted_report(), "../seed_create_bad.pdf");
     }
 
     // test sd list overflow
@@ -488,7 +488,7 @@ static void tests_device(void)
     u_assert_str_has(utils_read_decrypted_report(), AUTOBACKUP_FILENAME);
 
     api_format_send_cmd(cmd_str(CMD_seed),
-                        "{\"source\":\"create\", \"filename\":\"c.bak\", \"key\":\"password\"}", PASSWORD_STAND);
+                        "{\"source\":\"create\", \"filename\":\"c.pdf\", \"key\":\"password\"}", PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
     api_format_send_cmd(cmd_str(CMD_verifypass), attr_str(ATTR_create), PASSWORD_STAND);
@@ -502,7 +502,7 @@ static void tests_device(void)
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
     api_format_send_cmd(cmd_str(CMD_seed),
-                        "{\"source\":\"create\", \"filename\":\"l.bak\", \"key\":\"password\"}", PASSWORD_STAND);
+                        "{\"source\":\"create\", \"filename\":\"l.pdf\", \"key\":\"password\"}", PASSWORD_STAND);
     u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_IO_LOCKED));
 
     api_format_send_cmd(cmd_str(CMD_verifypass), attr_str(ATTR_create), PASSWORD_STAND);
@@ -741,7 +741,7 @@ static void tests_echo_tfa(void)
     u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_KEY_MASTER));
 
     api_format_send_cmd(cmd_str(CMD_seed),
-                        "{\"source\":\"create\", \"filename\":\"c.bak\", \"key\":\"password\"}", PASSWORD_STAND);
+                        "{\"source\":\"create\", \"filename\":\"c.pdf\", \"key\":\"password\"}", PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
     // test verifypass
@@ -928,7 +928,7 @@ static void tests_sign(void)
 
     // seed
     char seed[] =
-        "{\"source\":\"xprv9s21ZrQH143K3URucR3Zd2rRJBGGQsNFEo3Ld3JtTeUAQARegm573eJiNsAjGsyAj3h9roseS7GA7Y3dcub1pLpQD3eud2XzkoCoFpYBLF3\", \"filename\":\"s.bak\"}";
+        "{\"source\":\"xprv9s21ZrQH143K3URucR3Zd2rRJBGGQsNFEo3Ld3JtTeUAQARegm573eJiNsAjGsyAj3h9roseS7GA7Y3dcub1pLpQD3eud2XzkoCoFpYBLF3\", \"filename\":\"s.pdf\"}";
     api_format_send_cmd(cmd_str(CMD_seed), seed, PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
 
@@ -1146,7 +1146,7 @@ static void tests_aes_cbc(void)
     };
 
     char seed[] =
-        "{\"source\":\"xprv9s21ZrQH143K2MkmL8hdyZk5uwTPEqkwS72jXDt5DGRtUVrfYiAvAnGmxmP3J5Z3BG5uQcy5UYUMDsqisyXEDNCG2uzixsckhnfCrJxKVme\", \"filename\":\"x.bak\"}";
+        "{\"source\":\"xprv9s21ZrQH143K2MkmL8hdyZk5uwTPEqkwS72jXDt5DGRtUVrfYiAvAnGmxmP3J5Z3BG5uQcy5UYUMDsqisyXEDNCG2uzixsckhnfCrJxKVme\", \"filename\":\"x.pdf\"}";
 
     api_reset_device();
 


### PR DESCRIPTION
Motivation: can insert the SD card into a printer to print the encrypted backup on paper.

- NOT BACKWARD COMPATIBLE -
Old backups cannot be loaded - an error would be returned if it is tried. However, old backups already can not be loaded due to an update in the desktop app for the next release that corrects the BIP32 key paths -- i.e. old backups would load without error, but no coins would be found on the new key paths, giving a zero balance in the desktop app. Probably giving an error is better situation than showing a zero balance.

TODO
The desktop app should pass the backup file name using a .pdf extension.
Put recovery instructions on website. (Include client-side javascript to decrypt?)

![screen shot 2016-05-29 at 13 14 01](https://cloud.githubusercontent.com/assets/7711591/15632881/6dee5cd6-259f-11e6-88aa-3de9069290c7.png)


