### PR TITLE
add led abort (quick flashes) command

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -1104,14 +1104,14 @@ static void commander_process_led(yajl_val json_node)
         return;
     }
 
-    if (strncmp(value, attr_str(ATTR_toggle),
-                strlens(attr_str(ATTR_toggle))) != 0) {
-        commander_fill_report(cmd_str(CMD_led), NULL, DBB_ERR_IO_INVALID_CMD);
-    } else {
-        led_toggle();
-        delay_ms(300);
-        led_toggle();
+    if (!strncmp(value, attr_str(ATTR_toggle), strlens(attr_str(ATTR_toggle)))) {
+        led_blink();
         commander_fill_report(cmd_str(CMD_led), attr_str(ATTR_toggle), DBB_OK);
+    } else if (!strncmp(value, attr_str(ATTR_abort), strlens(attr_str(ATTR_abort)))) {
+        led_abort();
+        commander_fill_report(cmd_str(CMD_led), attr_str(ATTR_abort), DBB_OK);
+    } else {
+        commander_fill_report(cmd_str(CMD_led), NULL, DBB_ERR_IO_INVALID_CMD);
     }
 }
 

--- a/src/flags.h
+++ b/src/flags.h
@@ -144,6 +144,7 @@ X(verify)         \
 X(true)           \
 X(false)          \
 X(erase)          \
+X(abort)          \
 X(toggle)         \
 X(pseudo)         \
 X(create)         \

--- a/src/led.c
+++ b/src/led.c
@@ -75,6 +75,27 @@ void led_toggle(void)
 }
 
 
+void led_blink(void)
+{
+    led_on();
+    delay_ms(300);
+    led_off();
+}
+
+
+void led_abort(void)
+{
+    led_off();
+    delay_ms(300);
+    led_on();
+    delay_ms(100);
+    led_off();
+    delay_ms(100);
+    led_on();
+    delay_ms(100);
+    led_off();
+}
+
 void led_code(uint8_t *code, uint8_t len)
 {
     uint8_t i, j;

--- a/src/led.h
+++ b/src/led.h
@@ -38,6 +38,8 @@
 void led_on(void);
 void led_off(void);
 void led_toggle(void);
+void led_blink(void);
+void led_abort(void);
 void led_code(uint8_t *code, uint8_t len);
 
 

--- a/src/touch.c
+++ b/src/touch.c
@@ -163,21 +163,12 @@ uint8_t touch_button_press(uint8_t touch_type)
         if (touch_type == DBB_TOUCH_LONG_BLINK || touch_type == DBB_TOUCH_LONG) {
             led_off();
             delay_ms(300);
-            led_on();
-            delay_ms(300);
+            led_blink();
         }
         led_off();
         return DBB_TOUCHED;
     } else if (pushed == DBB_TOUCHED_ABORT) {
-        led_off();
-        delay_ms(300);
-        led_on();
-        delay_ms(100);
-        led_off();
-        delay_ms(100);
-        led_on();
-        delay_ms(100);
-        led_off();
+        led_abort();
         return DBB_ERR_TOUCH_ABORT;
     } else {
         led_off();


### PR DESCRIPTION
To be called when the cancel button is pushed in the dbb-app smart verification dialogs.