### PR TITLE
return 'success' for led commands; rename command 'toggle' to 'blink'; add tests

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -1104,12 +1104,12 @@ static void commander_process_led(yajl_val json_node)
         return;
     }
 
-    if (!strncmp(value, attr_str(ATTR_toggle), strlens(attr_str(ATTR_toggle)))) {
+    if (!strncmp(value, attr_str(ATTR_blink), strlens(attr_str(ATTR_blink)))) {
         led_blink();
-        commander_fill_report(cmd_str(CMD_led), attr_str(ATTR_toggle), DBB_OK);
+        commander_fill_report(cmd_str(CMD_led), attr_str(ATTR_success), DBB_OK);
     } else if (!strncmp(value, attr_str(ATTR_abort), strlens(attr_str(ATTR_abort)))) {
         led_abort();
-        commander_fill_report(cmd_str(CMD_led), attr_str(ATTR_abort), DBB_OK);
+        commander_fill_report(cmd_str(CMD_led), attr_str(ATTR_success), DBB_OK);
     } else {
         commander_fill_report(cmd_str(CMD_led), NULL, DBB_ERR_IO_INVALID_CMD);
     }

--- a/src/flags.h
+++ b/src/flags.h
@@ -145,7 +145,7 @@ X(true)           \
 X(false)          \
 X(erase)          \
 X(abort)          \
-X(toggle)         \
+X(blink)          \
 X(pseudo)         \
 X(create)         \
 X(export)         \

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -431,8 +431,13 @@ static void tests_device(void)
     api_format_send_cmd(cmd_str(CMD_ping), "", PASSWORD_NONE);
     u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_password));
 
-    api_format_send_cmd(cmd_str(CMD_led), attr_str(ATTR_toggle), PASSWORD_STAND);
+    api_format_send_cmd(cmd_str(CMD_led), attr_str(ATTR_blink), PASSWORD_STAND);
     u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+    u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_success));
+
+    api_format_send_cmd(cmd_str(CMD_led), attr_str(ATTR_abort), PASSWORD_STAND);
+    u_assert_str_has_not(utils_read_decrypted_report(), attr_str(ATTR_error));
+    u_assert_str_has(utils_read_decrypted_report(), attr_str(ATTR_success));
 
     api_format_send_cmd(cmd_str(CMD_led), "invalid_cmd", PASSWORD_STAND);
     u_assert_str_has(utils_read_decrypted_report(), flag_msg(DBB_ERR_IO_INVALID_CMD));


### PR DESCRIPTION
updates #152 