### PR TITLE
add second password that resets device if used

### DIFF
--- a/src/flags.h
+++ b/src/flags.h
@@ -81,6 +81,7 @@ X(seed)           \
 X(reset)          \
 X(password)       \
 X(bootloader)     \
+X(set_reset_password)\
 X(REQUIRE_TOUCH)   /* placeholder - do not move */\
 /* parent keys  */\
 /*  w/o touch   */\
@@ -204,6 +205,7 @@ X(ERR_IO_DECRYPT,      108, "Could not decrypt.")\
 X(ERR_IO_JSON_PARSE,   109, "JSON parse error.")\
 X(ERR_IO_RESET,        110, "Too many failed access attempts. Device reset.")\
 X(ERR_IO_LOCKED,       111, "Device locked. Erase device to access this command.")\
+X(ERR_IO_PW_COLLIDE,   113, "Device password matches reset password. Disabling reset password.")\
 X(ERR_SEED_SD,         200, "Seed creation requires an SD card for automatic encrypted backup of the seed.")\
 X(ERR_SEED_SD_NUM,     201, "Too many backup files. Please remove one from the SD card.")\
 X(ERR_SEED_MEM,        202, "Could not allocate memory for seed.")\

--- a/src/memory.h
+++ b/src/memory.h
@@ -45,6 +45,8 @@
 #define MEM_AESKEY_STAND_ADDR           0x0400// Zone 4
 #define MEM_AESKEY_VERIFY_ADDR          0x0500// Zone 5
 #define MEM_AESKEY_CRYPT_ADDR           0x0600// Zone 6
+#define MEM_AESKEY_RESET_ADDR           0x0700// Zone 7
+
 
 // Default settings
 #define DEFAULT_unlocked  0xFF
@@ -54,6 +56,7 @@
 
 typedef enum PASSWORD_ID {
     PASSWORD_STAND,
+    PASSWORD_RESET,
     PASSWORD_STRETCH, /* for backups */
     PASSWORD_VERIFY,
     PASSWORD_MEMORY,
@@ -65,6 +68,7 @@ typedef enum PASSWORD_ID {
 int memory_setup(void);
 void memory_erase(void);
 void memory_erase_seed(void);
+void memory_erase_password_reset(void);
 void memory_clear(void);
 
 int memory_aeskey_is_erased(PASSWORD_ID id);

--- a/tests/api.h
+++ b/tests/api.h
@@ -38,6 +38,7 @@
 
 
 static const char tests_pwd[] = "0000";
+static const char reset_pwd[] = "reset";
 static char command_sent[COMMANDER_REPORT_SIZE] = {0};
 static int TEST_LIVE_DEVICE = 0;
 
@@ -90,11 +91,10 @@ static void api_hid_send(const char *cmd)
 }
 
 
-static void api_hid_send_encrypt(const char *cmd)
+static void api_hid_send_encrypt(const char *cmd, PASSWORD_ID id)
 {
     int enc_len;
-    char *enc = aes_cbc_b64_encrypt((const unsigned char *)cmd, strlens(cmd), &enc_len,
-                                    PASSWORD_STAND);
+    char *enc = aes_cbc_b64_encrypt((const unsigned char *)cmd, strlens(cmd), &enc_len, id);
     api_hid_send_len(enc, enc_len);
     free(enc);
 }
@@ -115,7 +115,7 @@ static void api_send_cmd(const char *command, PASSWORD_ID id)
         api_hid_send(command);
         api_hid_read();
     } else {
-        api_hid_send_encrypt(command);
+        api_hid_send_encrypt(command, id);
         api_hid_read();
     }
 #endif


### PR DESCRIPTION
Motivation is to erase device if in a compromised situation.
To set: `{"set_reset_password":"password"}`

Then any command sent to the device that is encrypted with this password will reset/erase the device. 