### PR TITLE
Add option to set a custom version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,19 @@ endif()
 set(VERSION_STRING "${GIT_COMMIT_HASH}")
 set(VERSION_STRING_SHORT "${GIT_COMMIT_HASH_SHORT}")
 
+
+if(CUSTOM_VERSION)
+    execute_process(COMMAND git "rev-parse" "--short" "HEAD" OUTPUT_VARIABLE GIT_COMMIT_HASH_SHORT WORKING_DIRECTORY ${CMAKE_SOURCE_DIR} OUTPUT_STRIP_TRAILING_WHITESPACE)
+    string(REPLACE "." ";" VERSION_LIST ${CUSTOM_VERSION})
+    list(GET VERSION_LIST 0 vMAJOR)
+    list(GET VERSION_LIST 1 MINOR)
+    list(GET VERSION_LIST 2 PATCH)
+    set(VERSION_STRING "v${CUSTOM_VERSION}-g${GIT_COMMIT_HASH_SHORT}")
+    set(VERSION_STRING_SHORT "v${MAJOR}.${MINOR}.${PATCH}")
+    set(VERSION_STRING_MAJOR ${MAJOR})
+    set(VERSION_STRING_MINOR ${MINOR})
+    set(VERSION_STRING_PATCH ${PATCH})
+endif()
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/version.h.in
                ${CMAKE_CURRENT_SOURCE_DIR}/src/version.h)
 
@@ -104,6 +117,7 @@ endif()
 
 message(STATUS "\n\n=============================================")
 message(STATUS "            - General -")
+message(STATUS "Custom Version:         ${CUSTOM_VERSION}")
 message(STATUS "MCU version:            ${VERSION_STRING}")
 message(STATUS "CMake version:          ${CMAKE_VERSION}")
 message(STATUS "System:                 ${CMAKE_SYSTEM}")


### PR DESCRIPTION
This is required if you want to compile a firmware that has a newer version while the git tag has not been created.
The dbb-desktop app may look for a corresponding firmware version.