### PR TITLE
Feature set: set bit (1) to enable U2F instead of unsetting bit

### DIFF
--- a/py/send_command.py
+++ b/py/send_command.py
@@ -24,6 +24,7 @@ try:
     message = '{"random":"pseudo"}' 
     message = '{"bootloader":"lock"}' 
     message = '{"bootloader":"unlock"}' 
+    message = '{"feature_set":{"U2F":false}}' 
     message = '{"led":"blink"}' 
 
 

--- a/src/memory.h
+++ b/src/memory.h
@@ -54,7 +54,7 @@
 
 
 // Extension flags
-#define MEM_EXT_FLAG_U2F  0x00000001// Flag to enable or disabled U2F
+#define MEM_EXT_MASK_U2F  0x00000001// Mask of bit to enable (1) or disable (0) U2F
 
 
 // Default settings
@@ -62,7 +62,7 @@
 #define DEFAULT_erased    0xFF
 #define DEFAULT_setup     0xFF
 #define DEFAULT_u2f_count 0xFFFFFFFF
-#define DEFAULT_ext_flags (0xFFFFFFFF & ~MEM_EXT_FLAG_U2F)// Enable U2F by default
+#define DEFAULT_ext_flags 0xFFFFFFFF// U2F enabled by default
 
 
 typedef enum PASSWORD_ID {

--- a/src/u2f_device.c
+++ b/src/u2f_device.c
@@ -419,8 +419,8 @@ static void u2f_device_cmd_cont(const USB_FRAME *f)
     u2f_state_continue = false;
 
     if ( (reader.cmd < U2FHID_VENDOR_FIRST) &&
-            (memory_report_ext_flags() & MEM_EXT_FLAG_U2F) ) {
-        // Abort U2F commands if the U2F bit is set (==U2F disabled).
+            !(memory_report_ext_flags() & MEM_EXT_MASK_U2F) ) {
+        // Abort U2F commands if the U2F bit is not set (==U2F disabled).
         // Vendor specific commands are passed through.
         u2f_send_err_hid(cid, U2FHID_ERR_CHANNEL_BUSY);
     } else {

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -517,6 +517,12 @@ static void tests_u2f(void)
     api_format_send_cmd(cmd_str(CMD_device), attr_str(ATTR_info), PASSWORD_STAND);
     u_assert_str_has(api_read_decrypted_report(), "\"U2F\":true");
 
+    api_format_send_cmd(cmd_str(CMD_feature_set), "{\"U2F\":\"false\"}", PASSWORD_STAND);
+    u_assert_str_has(api_read_decrypted_report(), flag_msg(DBB_ERR_IO_INVALID_CMD));
+
+    api_format_send_cmd(cmd_str(CMD_feature_set), "{\"U2F\":\"true\"}", PASSWORD_STAND);
+    u_assert_str_has(api_read_decrypted_report(), flag_msg(DBB_ERR_IO_INVALID_CMD));
+
     // Reset U2F
     api_format_send_cmd(cmd_str(CMD_reset), attr_str(ATTR_U2F), PASSWORD_STAND);
     u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_error));


### PR DESCRIPTION
Required so that old devices upgrading their firmware will have U2F enabled by default.