### PR TITLE
add USB interface to print debug messages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,11 +92,18 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/src/version.h.in
 # Source Definitions
 
 if(CONTINUOUS_INTEGRATION)
-  add_definitions(-DCONTINUOUS_INTEGRATION)
+    add_definitions(-DCONTINUOUS_INTEGRATION)
+endif()
+
+if(ENABLE_DEBUG_IFACE AND BUILD_TYPE STREQUAL "firmware")
+    add_definitions(-DENABLE_DEBUG_IFACE)
+    set(DEBUG_IFACE "ON")
+else()
+    set(DEBUG_IFACE "OFF")
 endif()
 
 if(BUILD_TYPE STREQUAL "test")
-  add_definitions(-DTESTING)
+    add_definitions(-DTESTING)
 endif()
 
 if(BUILD_TYPE STREQUAL "bootloader")
@@ -108,6 +115,9 @@ add_definitions(-DuECC_OPTIMIZATION_LEVEL=4)
 if(USE_SECP256K1_LIB)
     add_definitions(-DECC_USE_SECP256K1_LIB)
     add_definitions(-DSECP256K1_BUILD=1)
+    set(SECP_LIB "libsecp256k1")
+else()
+    set(SECP_LIB "uECC")
 endif()
 
 
@@ -131,11 +141,8 @@ message(STATUS "Verbose:                ${CMAKE_VERBOSE_MAKEFILE}")
 message(STATUS "Documentation:          ${BUILD_DOCUMENTATION}  (make doc)")
 message(STATUS "Coverage flags:         ${BUILD_COVERAGE}")
 message(STATUS "Debug symbols:          ${BUILD_VALGRIND}")
-if(USE_SECP256K1_LIB)
-    message(STATUS "SECP256k1 library:      libsecp256k1")
-else()
-    message(STATUS "SECP256k1 library:      uECC ")
-endif()
+message(STATUS "Debug USB interface:    ${DEBUG_IFACE}")
+message(STATUS "SECP256k1 library:      ${SECP_LIB}")
 message(STATUS "\n=============================================\n\n")
 
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,6 +88,7 @@ set(DRIVER-SOURCES
         drivers/common/services/usb/class/hid/device/udi_hid.c 
         drivers/common/services/usb/class/hid/device/u2f/udi_hid_u2f.c 
         drivers/common/services/usb/class/hid/device/hww/udi_hid_hww.c 
+        drivers/common/services/usb/class/hid/device/dbg/udi_hid_dbg.c 
         drivers/common/services/usb/class/composite/device/udi_composite_desc.c 
         drivers/common/services/usb/udc/udc.c 
         drivers/common/utils/interrupt/interrupt_sam_nvic.c 
@@ -141,6 +142,7 @@ set(DRIVER-INCLUDES
         drivers/common/services/usb/class/hid/device
         drivers/common/services/usb/class/hid/device/u2f
         drivers/common/services/usb/class/hid/device/hww
+        drivers/common/services/usb/class/hid/device/dbg
         drivers/common/services/usb/class/composite/device
         drivers/common/services/usb/udc
         drivers/common/utils

--- a/src/drivers/common/services/usb/class/hid/device/dbg/udi_hid_dbg.c
+++ b/src/drivers/common/services/usb/class/hid/device/dbg/udi_hid_dbg.c
@@ -1,0 +1,217 @@
+/**
+ * \file
+ *
+ * \brief USB Device Human Interface Device (HID) generic interface.
+ *
+ * Copyright (c) 2009-2014 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+
+#include "conf_usb.h"
+#include "usb_protocol.h"
+#include "udd.h"
+#include "udc.h"
+#include "udi_hid.h"
+#include "udi_hid_dbg.h"
+#include <string.h>
+
+
+bool udi_dbg_enable(void);
+void udi_dbg_disable(void);
+bool udi_dbg_setup(void);
+uint8_t udi_dbg_getsetting(void);
+
+// Global structure which contains standard UDI interface for UDC
+UDC_DESC_STORAGE udi_api_t udi_api_dbg = {
+	.enable = (bool(*)(void))udi_dbg_enable,
+	.disable = (void (*)(void))udi_dbg_disable,
+	.setup = (bool(*)(void))udi_dbg_setup,
+	.getsetting = (uint8_t(*)(void))udi_dbg_getsetting,
+	.sof_notify = NULL,
+};
+
+
+static bool udi_dbg_b_report_in_free;
+COMPILER_WORD_ALIGNED static uint8_t udi_dbg_rate;
+COMPILER_WORD_ALIGNED static uint8_t udi_dbg_protocol;
+COMPILER_WORD_ALIGNED static uint8_t udi_dbg_report_in[UDI_HID_REPORT_IN_SIZE];
+COMPILER_WORD_ALIGNED static uint8_t udi_dbg_report_feature[UDI_HID_REPORT_FEATURE_SIZE];
+
+
+//! HID report descriptor
+// If change length, need to change `udi_dbg_report_desc_t` in:
+// `drivers/common/services/usb/class/hid/device/dbg_udi_dbg_h`
+UDC_DESC_STORAGE udi_dbg_report_desc_t udi_dbg_report_desc = { {
+	0x06, 0xfe, 0xfe,   // USAGE_PAGE (Vendor Defined)
+	0x09, 0x01,         // USAGE
+	0xa1, 0x01,         // COLLECTION (Application)
+	// In Report
+    0x09, 0x20,         // USAGE (Input Report Data)
+	0x15, 0x00,         // LOGICAL_MINIMUM (0)
+	0x26, 0xff, 0x00,   // LOGICAL_MAXIMUM (255)
+	0x75, 0x08,         // REPORT_SIZE (8)
+	0x95, 0x40,         // REPORT_COUNT (64) 
+	0x81, 0x02,         // INPUT (Data,Var,Abs)
+    0xc0                // END_COLLECTION
+    }
+};
+
+/**
+ * \name Internal routines
+ */
+
+/**
+ * \brief Send a report to HID interface
+ *
+ */
+static bool udi_dbg_setreport(void);
+
+/**
+ * \brief Initialize UDD to receive setfeature data
+ */
+static void udi_dbg_setfeature_valid(void);
+
+
+/**
+ * \brief Callback called when the report is sent
+ *
+ * \param status     UDD_EP_TRANSFER_OK, if transfer is completed
+ * \param status     UDD_EP_TRANSFER_ABORT, if transfer is aborted
+ * \param nb_sent    number of data transfered
+ */
+static void udi_dbg_report_in_sent(udd_ep_status_t status,
+		iram_size_t nb_sent, udd_ep_id_t ep);
+
+
+//--------------------------------------------
+//------ Interface for UDI HID level
+
+bool udi_dbg_enable(void)
+{
+	// Initialize internal values
+	udi_dbg_rate = 0;
+	udi_dbg_protocol = 0;
+	udi_dbg_b_report_in_free = true;
+	return UDI_DBG_ENABLE_EXT();
+}
+
+
+void udi_dbg_disable(void)
+{
+	UDI_DBG_DISABLE_EXT();
+}
+
+
+bool udi_dbg_setup(void)
+{
+	return udi_hid_setup(&udi_dbg_rate,
+								&udi_dbg_protocol,
+								(uint8_t *) &udi_dbg_report_desc,
+								udi_dbg_setreport);
+}
+
+
+uint8_t udi_dbg_getsetting(void)
+{
+	return 0;
+}
+
+
+static bool udi_dbg_setreport(void)
+{
+	if ((USB_HID_REPORT_TYPE_FEATURE == (udd_g_ctrlreq.req.wValue >> 8))
+			&& (0 == (0xFF & udd_g_ctrlreq.req.wValue))
+			&& (sizeof(udi_dbg_report_feature) ==
+					udd_g_ctrlreq.req.wLength)) {
+		// Feature type on report ID 0
+		udd_g_ctrlreq.payload =
+				(uint8_t *) & udi_dbg_report_feature;
+		udd_g_ctrlreq.callback = udi_dbg_setfeature_valid;
+		udd_g_ctrlreq.payload_size =
+				sizeof(udi_dbg_report_feature);
+		return true;
+	}
+	return false;
+}
+
+
+//--------------------------------------------
+//------ Interface for application
+
+bool udi_dbg_send_report_in(const char *data)
+{
+	if (!udi_dbg_b_report_in_free)
+		return false;
+	irqflags_t flags = cpu_irq_save();
+	// Fill report
+	memset(&udi_dbg_report_in, 0,
+			sizeof(udi_dbg_report_in));
+	memcpy(&udi_dbg_report_in, data,
+	      		sizeof(udi_dbg_report_in));
+	udi_dbg_b_report_in_free =
+			!udd_ep_run(UDI_DBG_EP_IN,
+							false,
+							(uint8_t *) & udi_dbg_report_in,
+							sizeof(udi_dbg_report_in),
+							udi_dbg_report_in_sent);
+	cpu_irq_restore(flags);
+	return !udi_dbg_b_report_in_free;
+
+}
+
+
+//--------------------------------------------
+//------ Internal routines
+
+static void udi_dbg_setfeature_valid(void)
+{
+	if (sizeof(udi_dbg_report_feature) != udd_g_ctrlreq.payload_size)
+		return;	// Bad data
+	UDI_HID_SET_FEATURE(udi_dbg_report_feature);
+}
+
+
+static void udi_dbg_report_in_sent(udd_ep_status_t status,
+		iram_size_t nb_sent, udd_ep_id_t ep)
+{
+	UNUSED(status);
+	UNUSED(nb_sent);
+	UNUSED(ep);
+	udi_dbg_b_report_in_free = true;
+    UDI_HID_REPORT_SENT();
+}

--- a/src/drivers/common/services/usb/class/hid/device/dbg/udi_hid_dbg.h
+++ b/src/drivers/common/services/usb/class/hid/device/dbg/udi_hid_dbg.h
@@ -1,0 +1,102 @@
+/**
+ * \file
+ *
+ * \brief USB Device Human Interface Device (HID) generic interface.
+ *
+ * Copyright (c) 2009 - 2014 Atmel Corporation. All rights reserved.
+ *
+ * \asf_license_start
+ *
+ * \page License
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * 3. The name of Atmel may not be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * 4. This software may only be redistributed and used in connection with an
+ *    Atmel microcontroller product.
+ *
+ * THIS SOFTWARE IS PROVIDED BY ATMEL "AS IS" AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT ARE
+ * EXPRESSLY AND SPECIFICALLY DISCLAIMED. IN NO EVENT SHALL ATMEL BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * \asf_license_stop
+ *
+ */
+
+
+#ifndef _UDI_DBG_H_
+#define _UDI_DBG_H_
+
+
+#include "conf_usb.h"
+#include "usb_protocol.h"
+#include "usb_protocol_hid.h"
+#include "udc_desc.h"
+#include "udi.h"
+
+
+// Global structure which contains standard UDI API for UDC
+extern UDC_DESC_STORAGE udi_api_t udi_api_dbg;
+
+
+// Report descriptor for HID generic
+typedef struct {
+	uint8_t array[21];
+} udi_dbg_report_desc_t;
+
+
+// By default no string associated to this interface
+#ifndef UDI_DBG_STRING_ID
+#define UDI_DBG_STRING_ID 0
+#endif
+
+
+// Content of DBG interface descriptor for all speed
+#define UDI_DBG_DESC    {\
+   .iface.bLength             = sizeof(usb_iface_desc_t),\
+   .iface.bDescriptorType     = USB_DT_INTERFACE,\
+   .iface.bInterfaceNumber    = UDI_DBG_IFACE_NUMBER,\
+   .iface.bAlternateSetting   = 0,\
+   .iface.bNumEndpoints       = UDI_DBG_EP_COUNT,\
+   .iface.bInterfaceClass     = HID_CLASS,\
+   .iface.bInterfaceSubClass  = HID_SUB_CLASS_NOBOOT,\
+   .iface.bInterfaceProtocol  = HID_PROTOCOL_GENERIC,\
+   .iface.iInterface          = UDI_DBG_STRING_ID,\
+   .hid.bLength               = sizeof(usb_hid_descriptor_t),\
+   .hid.bDescriptorType       = USB_DT_HID,\
+   .hid.bcdHID                = LE16(USB_HID_BDC_V1_11),\
+   .hid.bCountryCode          = USB_HID_NO_COUNTRY_CODE,\
+   .hid.bNumDescriptors       = USB_HID_NUM_DESC,\
+   .hid.bRDescriptorType      = USB_DT_HID_REPORT,\
+   .hid.wDescriptorLength     = LE16(sizeof(udi_dbg_report_desc_t)),\
+   .ep_in.bLength             = sizeof(usb_ep_desc_t),\
+   .ep_in.bDescriptorType     = USB_DT_ENDPOINT,\
+   .ep_in.bEndpointAddress    = UDI_DBG_EP_IN,\
+   .ep_in.bmAttributes        = USB_EP_TYPE_INTERRUPT,\
+   .ep_in.wMaxPacketSize      = LE16(UDI_HID_EP_SIZE),\
+   .ep_in.bInterval           = 4,\
+    }
+
+
+bool udi_dbg_send_report_in(const char *data);
+
+
+#endif

--- a/src/drivers/config/conf_usb.h
+++ b/src/drivers/config/conf_usb.h
@@ -93,6 +93,13 @@ extern char usb_serial_number[];
 #define  UDI_U2F_REPORT_SENT()       usb_u2f_report_sent()
 
 
+#define  UDI_DBG_IFACE_NUMBER        2
+#define  UDI_DBG_EP_COUNT            1
+#define  UDI_DBG_EP_IN               (5 | USB_EP_DIR_IN)
+#define  UDI_DBG_ENABLE_EXT()        usb_dbg_enable()
+#define  UDI_DBG_DISABLE_EXT()       usb_dbg_disable()
+
+
 #define  UDI_HID_REPORT_SENT()       usb_report_sent()
 #define  UDI_HID_SET_FEATURE(report) usb_set_feature(report)
 
@@ -105,14 +112,26 @@ typedef struct {
 	usb_ep_desc_t ep_out;
 } udi_hid_generic_desc_t;
 
+typedef struct {
+	usb_iface_desc_t iface;
+	usb_hid_descriptor_t hid;
+	usb_ep_desc_t ep_in;
+} udi_hid_generic_dbg_desc_t;
 
-#ifdef BOOTLOADER 
+#if defined(BOOTLOADER)
 #define  USB_DEVICE_EP_CTRL_SIZE       64
 #define  USB_DEVICE_NB_INTERFACE       1
 #define  USB_DEVICE_MAX_EP             2
 #define  UDI_COMPOSITE_DESC_T           udi_hid_generic_desc_t hid_hww
 #define  UDI_COMPOSITE_DESC             .hid_hww = UDI_HWW_DESC
 #define  UDI_COMPOSITE_API              &udi_api_hww
+#elif defined(ENABLE_DEBUG_IFACE)
+#define  USB_DEVICE_EP_CTRL_SIZE       64
+#define  USB_DEVICE_NB_INTERFACE       3
+#define  USB_DEVICE_MAX_EP             5
+#define  UDI_COMPOSITE_DESC_T           udi_hid_generic_desc_t hid_hww; udi_hid_generic_desc_t hid_u2f; udi_hid_generic_dbg_desc_t hid_dbg
+#define  UDI_COMPOSITE_DESC             .hid_hww = UDI_HWW_DESC, .hid_u2f = UDI_U2F_DESC, .hid_dbg = UDI_DBG_DESC
+#define  UDI_COMPOSITE_API              &udi_api_hww, &udi_api_u2f, &udi_api_dbg
 #else
 #define  USB_DEVICE_EP_CTRL_SIZE       64
 #define  USB_DEVICE_NB_INTERFACE       2
@@ -126,6 +145,7 @@ typedef struct {
 // Keep these includes at the end of the file
 #include "udi_hid_hww.h"
 #include "udi_hid_u2f.h"
+#include "udi_hid_dbg.h"
 
 
 #endif

--- a/src/usb.c
+++ b/src/usb.c
@@ -43,6 +43,7 @@
 
 static bool usb_hww_enabled = false;
 static bool usb_u2f_enabled = false;
+static bool usb_dbg_enabled = false;
 static uint8_t usb_hww_interface_occupied = 0;
 static uint8_t usb_reply_queue_packets[USB_QUEUE_NUM_PACKETS][USB_REPORT_SIZE];
 static uint32_t usb_reply_queue_index_start = 0;
@@ -97,6 +98,20 @@ void usb_reply(uint8_t *report)
             udi_u2f_send_report_in(report);
         }
 #endif
+#endif
+    }
+}
+
+
+void usb_reply_dbg(const char *msg, size_t len)
+{
+    if (msg && len) {
+#if defined(ENABLE_DEBUG_IFACE)
+        // TODO - send multiple reports if msg length > report size
+        static char report[USB_REPORT_SIZE];
+        memset(report, 0, USB_REPORT_SIZE);
+        memcpy(report, msg, len < USB_REPORT_SIZE ? len : USB_REPORT_SIZE);
+        udi_dbg_send_report_in(report);
 #endif
     }
 }
@@ -216,6 +231,19 @@ bool usb_hww_enable(void)
 void usb_hww_disable(void)
 {
     usb_hww_enabled = false;
+}
+
+
+bool usb_dbg_enable(void)
+{
+    usb_dbg_enabled = true;
+    return true;
+}
+
+
+void usb_dbg_disable(void)
+{
+    usb_dbg_enabled = false;
 }
 
 

--- a/src/usb.h
+++ b/src/usb.h
@@ -71,6 +71,7 @@ void usb_reply_queue_load_msg(const uint8_t cmd, const uint8_t *data, const uint
 void usb_reply_queue_send(void);
 uint8_t *usb_reply_queue_read(void);
 void usb_reply(uint8_t *report);
+void usb_reply_dbg(const char *msg, size_t len);
 
 void usb_process(uint16_t framenumber);
 void usb_sof_action(void);
@@ -89,6 +90,9 @@ void usb_hww_report(const unsigned char *command);
 bool usb_u2f_enable(void);
 void usb_u2f_disable(void);
 void usb_u2f_report(const unsigned char *command);
+
+bool usb_dbg_enable(void);
+void usb_dbg_disable(void);
 
 
 #endif


### PR DESCRIPTION
Activated by `cmake` command (for `firmware` builds only):
```
cmake .. -DBUILD_TYPE=firmware -DENABLE_DEBUG_IFACE=1
```

To send a debug message, use `void usb_reply_dbg(const char *msg, size_t len)`. Currently limited to 64 characters per `msg`.