### PR TITLE
170505/recid api

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -271,15 +271,15 @@ const char *commander_read_array(void)
 }
 
 
-int commander_fill_signature_array(const uint8_t sig[64], const uint8_t pubkey[33])
+int commander_fill_signature_array(const uint8_t sig[64], uint8_t recid)
 {
+    char recid_c[2 + 1] = {0};
     char sig_c[128 + 1] = {0};
-    char pub_key_c[66 + 1] = {0};
+    snprintf(recid_c, sizeof(recid_c), "%02x", recid);
     snprintf(sig_c, sizeof(sig_c), "%s", utils_uint8_to_hex(sig, 64));
-    snprintf(pub_key_c, sizeof(pub_key_c), "%s", utils_uint8_to_hex(pubkey, 33));
-    const char *key[] = {cmd_str(CMD_sig), cmd_str(CMD_pubkey), 0};
-    const char *value[] = {sig_c, pub_key_c, 0};
-    int type[] = {DBB_JSON_STRING, DBB_JSON_STRING, DBB_JSON_NONE};
+    const char *key[] = {cmd_str(CMD_sig), cmd_str(CMD_recid), 0};
+    const char *value[] = {sig_c, recid_c, 0};
+    int type[] = {DBB_JSON_STRING, DBB_JSON_STRING, DBB_JSON_STRING, DBB_JSON_NONE};
     return commander_fill_json_array(key, value, type, CMD_sign);
 }
 

--- a/src/commander.h
+++ b/src/commander.h
@@ -42,7 +42,7 @@ void commander_clear_report(void);
 const char *commander_read_report(void);
 const char *commander_read_array(void);
 void commander_fill_report(const char *attr, const char *val, int err);
-int commander_fill_signature_array(const uint8_t *sig, const uint8_t *pubkey);
+int commander_fill_signature_array(const uint8_t *sig, uint8_t recid);
 int commander_fill_json_array(const char **key, const char **value, int *type,
                               int cmd);
 void commander_force_reset(void);

--- a/src/flags.h
+++ b/src/flags.h
@@ -48,8 +48,8 @@
 
 
 #define COMMANDER_REPORT_SIZE       4096
-#define COMMANDER_SIG_LEN           219// sig + pubkey + json encoding
-#define COMMANDER_ARRAY_MAX         (COMMANDER_REPORT_SIZE - (COMMANDER_SIG_LEN / 2))
+#define COMMANDER_SIG_LEN           154// sig + recid + json formatting
+#define COMMANDER_ARRAY_MAX         (COMMANDER_REPORT_SIZE - (COMMANDER_SIG_LEN * 10))
 #define COMMANDER_ARRAY_ELEMENT_MAX 1024
 #define COMMANDER_MAX_ATTEMPTS      15// max PASSWORD or LOCK PIN attempts before device reset
 #define COMMANDER_TOUCH_ATTEMPTS    10// number of attempts until touch button hold required to login
@@ -113,6 +113,7 @@ X(erase)          \
 X(check)          \
 X(key)            \
 X(sig)            \
+X(recid)          \
 X(pin)            \
 X(U2F)            \
 /*  reply keys  */\

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -301,7 +301,7 @@ int wallet_sign(const char *message, const char *keypath)
 {
     uint8_t data[32];
     uint8_t sig[64];
-    uint8_t pub_key[33];
+    uint8_t recid = 0xEE;// Set default value to give an error when trying to recover
     HDNode node;
 
     if (strlens(message) != (32 * 2)) {
@@ -325,15 +325,14 @@ int wallet_sign(const char *message, const char *keypath)
 
     memcpy(data, utils_hex_to_uint8(message), 32);
 
-    if (bitcoin_ecc.ecc_sign_digest(node.private_key, data, sig, NULL, ECC_SECP256k1)) {
+    if (bitcoin_ecc.ecc_sign_digest(node.private_key, data, sig, &recid, ECC_SECP256k1)) {
         commander_clear_report();
         commander_fill_report(cmd_str(CMD_sign), NULL, DBB_ERR_SIGN_ECCLIB);
         goto err;
     }
 
-    bitcoin_ecc.ecc_get_public_key33(node.private_key, pub_key, ECC_SECP256k1);
     utils_zero(&node, sizeof(HDNode));
-    return commander_fill_signature_array(sig, pub_key);
+    return commander_fill_signature_array(sig, recid);
 
 err:
     utils_zero(&node, sizeof(HDNode));

--- a/tests/api.h
+++ b/tests/api.h
@@ -160,6 +160,13 @@ static int api_hid_send_frame(USB_FRAME *f)
 
 static int api_hid_send_frames(uint32_t cid, uint8_t cmd, const void *data, size_t size)
 {
+    if (size > COMMANDER_REPORT_SIZE) {
+        u_print_error("ERROR  - %s() - Line %d\n", __func__, __LINE__);
+        u_print_error("\tCommand size exceeds buffer size by %lu bytes.\n",
+                      size - COMMANDER_REPORT_SIZE);
+        return 0;
+    }
+
     USB_FRAME frame;
     int res;
     size_t frameLen;

--- a/tests/tests_unit.c
+++ b/tests/tests_unit.c
@@ -950,13 +950,13 @@ static void test_buffer_overflow(void)
     u_assert_str_has(commander_read_report(), flag_msg(DBB_ERR_IO_REPORT_BUF));
 
     uint8_t sig[64] = {0};
-    uint8_t pubkey[33] = {0};
+    uint8_t recid = 0;
 
     commander_clear_report();
-    val[COMMANDER_REPORT_SIZE - sizeof(sig) - sizeof(pubkey) - strlens(flag_msg(
+    val[COMMANDER_REPORT_SIZE - sizeof(sig) - sizeof(recid) - strlens(flag_msg(
                                       DBB_ERR_IO_REPORT_BUF))] = '\0';
     commander_fill_report("testing", val, DBB_OK);
-    commander_fill_signature_array(sig, pubkey);
+    commander_fill_signature_array(sig, recid);
     commander_fill_report("sign", commander_read_array(), DBB_OK);
     u_assert_str_has(commander_read_report(), flag_msg(DBB_ERR_IO_REPORT_BUF));
 }

--- a/tests/utest.h
+++ b/tests/utest.h
@@ -84,22 +84,32 @@
   printf("\x1b[0m"); \
 } while (0)
 
+#define u_print_error(...) do {\
+  printf("\x1b[31m"); \
+  printf(__VA_ARGS__); \
+  printf("\x1b[0m"); \
+} while (0)
+
+#define u_print_success(...) do {\
+  printf("\x1b[32m"); \
+  printf(__VA_ARGS__); \
+  printf("\x1b[0m"); \
+} while (0)
+
 #define u_run_test(TEST) do {\
  int f_ = U_TESTS_FAIL; \
  TEST();  U_TESTS_RUN++; \
  if (f_ == U_TESTS_FAIL) { \
-  printf("\x1b[32mPASSED - %s()\x1b[0m\n", #TEST); };\
+  u_print_success("PASSED - %s()\n", #TEST); };\
 } while (0)
 
 #define u_assert_int_eq(R,E) {\
  int r_ = (R); \
  int e_ = (E); \
  do { if (r_!=e_) { \
-  printf("\x1b[31m");\
-  printf("FAILED - %s() - Line %d\n", __func__, __LINE__);\
-  printf("\tExpect: \t%d\n", e_);\
-  printf("\tReceive:\t%d\n", r_);\
-  printf("\x1b[0m");\
+  u_print_error("FAILED - %s() - Line %d\n", __func__, __LINE__);\
+  u_print_error("\tExpect: \t%d\n", e_);\
+  u_print_error("\tReceive:\t%d\n", r_);\
   U_TESTS_FAIL++;\
   return; }; \
  } while(0); }
@@ -108,11 +118,9 @@
  const char * r_ = (R); \
  const char * e_ = (E); \
  do { if (strcmp(r_,e_)) { \
-  printf("\x1b[31m");\
-  printf("FAILED - %s() - Line %d\n", __func__, __LINE__);\
-  printf("\tExpect: \t%s\n", e_);\
-  printf("\tReceive:\t%s\n", r_);\
-  printf("\x1b[0m");\
+  u_print_error("FAILED - %s() - Line %d\n", __func__, __LINE__);\
+  u_print_error("\tExpect: \t%s\n", e_);\
+  u_print_error("\tReceive:\t%s\n", r_);\
   U_TESTS_FAIL++;\
   return; }; \
  } while(0); }
@@ -121,11 +129,9 @@
  const char * r_ = (R); \
  const char * e_ = (E); \
  do { if (!strcmp(r_,e_)) { \
-  printf("\x1b[31m");\
-  printf("FAILED - %s() - Line %d\n", __func__, __LINE__);\
-  printf("\tNot expect:\t%s\n", e_);\
-  printf("\tReceive:\t%s\n", r_);\
-  printf("\x1b[0m");\
+  u_print_error("FAILED - %s() - Line %d\n", __func__, __LINE__);\
+  u_print_error("\tNot expect:\t%s\n", e_);\
+  u_print_error("\tReceive:\t%s\n", r_);\
   U_TESTS_FAIL++;\
   return; }; \
  } while(0); }
@@ -134,11 +140,9 @@
  const char * r_ = (R); \
  const char * e_ = (E); \
  do { if (!strstr(r_,e_)) { \
-  printf("\x1b[31m");\
-  printf("FAILED - %s() - Line %d\n", __func__, __LINE__);\
-  printf("\tExpect: \t%s\n", e_);\
-  printf("\tReceive:\t%s\n", r_);\
-  printf("\x1b[0m");\
+  u_print_error("FAILED - %s() - Line %d\n", __func__, __LINE__);\
+  u_print_error("\tExpect: \t%s\n", e_);\
+  u_print_error("\tReceive:\t%s\n", r_);\
   U_TESTS_FAIL++;\
   return; }; \
  } while(0); }
@@ -147,11 +151,9 @@
  const char * r_ = (R); \
  const char * e_ = (E); \
  do { if (strstr(r_,e_)) { \
-  printf("\x1b[31m");\
-  printf("FAILED - %s() - Line %d\n", __func__, __LINE__);\
-  printf("\tNot expect:\t%s\n", e_);\
-  printf("\tReceive:\t%s\n", r_);\
-  printf("\x1b[0m");\
+  u_print_error("FAILED - %s() - Line %d\n", __func__, __LINE__);\
+  u_print_error("\tNot expect:\t%s\n", e_);\
+  u_print_error("\tReceive:\t%s\n", r_);\
   U_TESTS_FAIL++;\
   return; }; \
  } while(0); }
@@ -161,11 +163,9 @@
  const void * e_ = (E); \
  size_t l_ = (L); \
  do { if (memcmp(r_,e_,l_)) { \
-  printf("\x1b[31m");\
-  printf("FAILED - %s() - Line %d\n", __func__, __LINE__);\
-  printf("\tExpect: \t%s\n", utils_uint8_to_hex(e_,l_));\
-  printf("\tReceive:\t%s\n", utils_uint8_to_hex(r_,l_));\
-  printf("\x1b[0m");\
+  u_print_error("FAILED - %s() - Line %d\n", __func__, __LINE__);\
+  u_print_error("\tExpect: \t%s\n", utils_uint8_to_hex(e_,l_));\
+  u_print_error("\tReceive:\t%s\n", utils_uint8_to_hex(r_,l_));\
   U_TESTS_FAIL++;\
   return; }; \
  } while(0); }
@@ -175,11 +175,9 @@
  const void * e_ = (E); \
  size_t l_ = (L); \
  do { if (!memcmp(r_,e_,l_)) { \
-  printf("\x1b[31m");\
-  printf("FAILED - %s() - Line %d\n", __func__, __LINE__);\
-  printf("\tExpect: \t%s\n", utils_uint8_to_hex(e_,l_));\
-  printf("\tReceive:\t%s\n", utils_uint8_to_hex(r_,l_));\
-  printf("\x1b[0m");\
+  u_print_error("FAILED - %s() - Line %d\n", __func__, __LINE__);\
+  u_print_error("\tExpect: \t%s\n", utils_uint8_to_hex(e_,l_));\
+  u_print_error("\tReceive:\t%s\n", utils_uint8_to_hex(r_,l_));\
   U_TESTS_FAIL++;\
   return; }; \
  } while(0); }


### PR DESCRIPTION
Since the libsecp256k1 recoverable signatures function is now used by default in the firmware, we can replace `pubkey` by `recid` in the returned JSON of the `sign` command. The motivation is to save space and allow a potential ethereum integration through the HWW interface. The change has no effect on the current desktop app except the need to delete an unused line of code (https://github.com/digitalbitbox/dbb-app/pull/268). The electrum plugin needs to be updated.

This changes the API (https://digitalbitbox.com/api) from:
```
"sign" : 
{
      "pubkey" : "pubkey",
      "sig" : "signature"
}
```
to:
```
"sign" : 
{
      "recid" : "00",
      "sig" : "signature"
}
```

`recid` is a 2-character (1-byte) hexadecimal string in order to match the `signature` format.