### PR TITLE
[WIP] Always backup U2F seed (plaintext hex)

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -518,6 +518,7 @@ static void commander_process_seed(yajl_val json_node)
     const char *source_path[] = { cmd_str(CMD_seed), cmd_str(CMD_source), NULL };
     const char *entropy_path[] = { cmd_str(CMD_seed), cmd_str(CMD_entropy), NULL };
     const char *filename_path[] = { cmd_str(CMD_seed), cmd_str(CMD_filename), NULL };
+    const char *u2f_counter_path[] = { cmd_str(CMD_seed), cmd_str(CMD_U2F_counter), NULL };
 
     const char *key = YAJL_GET_STRING(yajl_tree_get(json_node, key_path, yajl_t_string));
     const char *raw = YAJL_GET_STRING(yajl_tree_get(json_node, raw_path, yajl_t_string));
@@ -527,6 +528,9 @@ static void commander_process_seed(yajl_val json_node)
                                           yajl_t_string));
     const char *filename = YAJL_GET_STRING(yajl_tree_get(json_node, filename_path,
                                            yajl_t_string));
+    yajl_val u2f_counter_data = yajl_tree_get(json_node, u2f_counter_path,
+                                              yajl_t_number);
+    long long u2f_counter = YAJL_GET_INTEGER(u2f_counter_data);
 
     if (wallet_is_locked()) {
         commander_fill_report(cmd_str(CMD_seed), NULL, DBB_ERR_IO_LOCKED);
@@ -628,6 +632,12 @@ static void commander_process_seed(yajl_val json_node)
 
         utils_zero(backup_hex, strlens(backup_hex));
         utils_zero(entropy_c, sizeof(entropy_c));
+
+        /* see if we should set the counter */
+        if(u2f_counter_data) {
+            memory_u2f_count_set(u2f_counter);
+        }
+
         source_found = 1;
     }
     if (strcmp(source, attr_str(ATTR_backup)) == 0 || strcmp(source, attr_str(ATTR_backupu2f)) == 0) {

--- a/src/flags.h
+++ b/src/flags.h
@@ -118,6 +118,7 @@ X(recid)          \
 X(pin)            \
 X(U2F)            \
 X(U2F_hijack)     \
+X(U2F_counter)    \
 /*  reply keys  */\
 X(ciphertext)     \
 X(echo)           \

--- a/src/flags.h
+++ b/src/flags.h
@@ -153,6 +153,8 @@ X(blink)          \
 X(pseudo)         \
 X(create)         \
 X(backup)         \
+X(backupwallet)\
+X(backupu2f)\
 X(export)         \
 X(xpub)           \
 X(id)             \
@@ -192,6 +194,8 @@ X(MEM_ERASED,            0, 0)\
 X(MEM_NOT_ERASED,        0, 0)\
 X(SD_REPLACE,            0, 0)\
 X(SD_NO_REPLACE,         0, 0)\
+X(SD_TYPE_PDF,           0, 0)\
+X(SD_TYPE_TXT,           0, 0)\
 X(JSON_STRING,           0, 0)\
 X(JSON_BOOL,             0, 0)\
 X(JSON_ARRAY,            0, 0)\

--- a/src/memory.c
+++ b/src/memory.c
@@ -532,6 +532,10 @@ uint32_t memory_u2f_count_iter(void)
     memory_eeprom((uint8_t *)&c, (uint8_t *)&MEM_u2f_count, MEM_U2F_COUNT_ADDR, 4);
     return MEM_u2f_count;
 }
+void memory_u2f_count_set(uint32_t c)
+{
+    memory_eeprom((uint8_t *)&c, (uint8_t *)&MEM_u2f_count, MEM_U2F_COUNT_ADDR, 4);
+}
 uint32_t memory_u2f_count_read(void)
 {
     memory_eeprom(NULL, (uint8_t *)&MEM_u2f_count, MEM_U2F_COUNT_ADDR, 4);

--- a/src/memory.h
+++ b/src/memory.h
@@ -114,6 +114,7 @@ uint16_t memory_pin_err_count(const uint8_t access);
 uint16_t memory_read_pin_err_count(void);
 
 uint32_t memory_u2f_count_iter(void);
+void memory_u2f_count_set(uint32_t c);
 uint32_t memory_u2f_count_read(void);
 
 

--- a/src/sd.h
+++ b/src/sd.h
@@ -53,9 +53,9 @@ uint8_t sd_list(int cmd);
 uint8_t sd_card_inserted(void);
 uint8_t sd_file_exists(const char *fn);
 uint8_t sd_erase(int cmd, const char *fn);
-char *sd_load(const char *fn, int cmd);
+char *sd_load(const char *fn, uint8_t type, int cmd);
 uint8_t sd_write(const char *fn, const char *wallet_backup, const char *wallet_name,
-                 uint8_t replace, int cmd);
+                 uint8_t replace, uint8_t type, int cmd);
 
 
 #endif

--- a/src/sham.c
+++ b/src/sham.c
@@ -37,6 +37,9 @@
 static char sd_filename[64] = {0};
 static char sd_text[512] = {0};
 
+static char sd_filename_u2f[64] = {0};
+static char sd_text_u2f[512] = {0};
+
 void delay_ms(int delay)
 {
     (void) delay;
@@ -44,27 +47,50 @@ void delay_ms(int delay)
 
 
 uint8_t sd_write(const char *fn, const char *t, const char *name, uint8_t replace,
-                 int cmd)
+                 uint8_t type, int cmd)
 {
     (void) replace;
     (void) cmd;
-    memset(sd_filename, 0, sizeof(sd_filename));
-    memset(sd_text, 0, sizeof(sd_text));
-    snprintf(sd_filename, sizeof(sd_filename), "%.*s", (int)strlens(fn), fn);
-    snprintf(sd_text, sizeof(sd_text), "%.*s%c%s", (int)strlens(t), t, BACKUP_DELIM, name);
-    commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
+    (void) type;
+    if (type == DBB_SD_TYPE_PDF) {
+        /* only write the HWW backup */
+        memset(sd_filename, 0, sizeof(sd_filename));
+        memset(sd_text, 0, sizeof(sd_text));
+        snprintf(sd_filename, sizeof(sd_filename), "%.*s", (int)strlens(fn), fn);
+        snprintf(sd_text, sizeof(sd_text), "%.*s%c%s", (int)strlens(t), t, BACKUP_DELIM, name);
+        commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
+    }
+    else if (type == DBB_SD_TYPE_TXT) {
+        /* only write the HWW backup */
+        memset(sd_filename_u2f, 0, sizeof(sd_filename_u2f));
+        memset(sd_text_u2f, 0, sizeof(sd_text_u2f));
+        snprintf(sd_filename_u2f, sizeof(sd_filename_u2f), "%.*s", (int)strlens(fn), fn);
+        snprintf(sd_text_u2f, sizeof(sd_text_u2f), "%.*s", (int)strlens(t), t);
+        commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
+    }
     return DBB_OK;
 }
 
 
-char *sd_load(const char *fn, int cmd)
+char *sd_load(const char *fn, uint8_t type, int cmd)
 {
     (void) cmd;
     static char text[sizeof(sd_text)];
-    memcpy(text, sd_text, sizeof(sd_text));
-    commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
-    if (!strncmp(sd_filename, fn, strlens(fn))) {
-        return text;
+    if (type == DBB_SD_TYPE_PDF) {
+        memcpy(text, sd_text, sizeof(sd_text));
+
+        commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
+        if (!strncmp(sd_filename, fn, strlens(fn))) {
+            return text;
+        }
+    }
+    else {
+        memcpy(text, sd_text_u2f, sizeof(sd_text_u2f));
+
+        commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
+        if (!strncmp(sd_filename_u2f, fn, strlens(fn))) {
+            return text;
+        }
     }
     return NULL;
 }
@@ -91,7 +117,7 @@ uint8_t sd_file_exists(const char *fn)
 {
     (void) fn;
     commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
-    if (!strncmp(sd_filename, fn, strlens(fn))) {
+    if ( (strlen(sd_filename) == strlens(fn) &&  !strncmp(sd_filename, fn, strlens(fn))) || (strlen(sd_filename_u2f) == strlens(fn) && !strncmp(sd_filename_u2f, fn, strlens(fn)))) {
         return DBB_OK;
     }
     return DBB_ERROR;
@@ -103,8 +129,14 @@ uint8_t sd_erase(int cmd, const char *fn)
     (void) cmd;
     (void) fn;
     commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
-    memset(sd_filename, 0, sizeof(sd_filename));
-    memset(sd_text, 0, sizeof(sd_text));
+    if (!strncmp(sd_filename, fn, strlens(fn)) || fn == NULL) {
+        memset(sd_filename, 0, sizeof(sd_filename));
+        memset(sd_text, 0, sizeof(sd_text));
+    }
+    if (!strncmp(sd_filename, fn, strlens(fn)) || fn == NULL) {
+        memset(sd_filename_u2f, 0, sizeof(sd_filename_u2f));
+        memset(sd_text_u2f, 0, sizeof(sd_text_u2f));
+    }
     return DBB_OK;
 }
 

--- a/src/sham.h
+++ b/src/sham.h
@@ -33,9 +33,9 @@
 
 
 void delay_ms(int delay);
-char *sd_load(const char *f, int cmd);
+char *sd_load(const char *f, uint8_t type, int cmd);
 uint8_t sd_write(const char *f, const char *t, const char *name, uint8_t replace,
-                 int cmd);
+                 uint8_t type, int cmd);
 uint8_t sd_list(int cmd);
 uint8_t sd_card_inserted(void);
 uint8_t sd_file_exists(const char *fn);

--- a/src/utils.c
+++ b/src/utils.c
@@ -225,3 +225,19 @@ int utils_varint_to_uint64(const char *vi, uint64_t *i)
 
     return len;
 }
+
+static const char *PDF_FILE_EXT= ".pdf";
+
+void utils_get_u2f_bak_f(const char *p, char *s) {
+    unsigned long length_base = strlen(p);
+    if (length_base > strlen(PDF_FILE_EXT) && memcmp(p+length_base-strlen(PDF_FILE_EXT), PDF_FILE_EXT, strlen(PDF_FILE_EXT)) == 0) {
+        length_base -= strlen(PDF_FILE_EXT);
+    }
+    else {
+        memcpy(s, p, strlen(p)+1);
+        return;
+    }
+    memcpy(s, p, length_base);
+    memcpy(s+length_base, U2F_BAK_FILE_EXT, strlen(U2F_BAK_FILE_EXT));
+    s[length_base+strlen(U2F_BAK_FILE_EXT)] = 0; /* set terminating 0 byte */
+}

--- a/src/utils.h
+++ b/src/utils.h
@@ -40,6 +40,7 @@
 #define MAX(a, b)  (((a) > (b)) ? (a) : (b))
 #define strlens(s) (s == NULL ? 0 : strlen(s))
 
+#define U2F_BAK_FILE_EXT ".u2f"
 
 volatile void *utils_zero(volatile void *dst, size_t len);
 void utils_clear_buffers(void);
@@ -52,5 +53,10 @@ void utils_reverse_bin(uint8_t *b, int len);
 void utils_uint64_to_varint(char *vi, int *l, uint64_t i);
 int utils_varint_to_uint64(const char *vi, uint64_t *i);
 
+/* writes the filename *p to *s, removes a possible .pdf
+ * file extenstions and adds .u2f
+ * *s musst be of size strlen(p)+strlen(U2F_BAK_FILE_EXT)+1
+ */
+void utils_get_u2f_bak_f(const char *p, char *s);
 
 #endif

--- a/tests/u2f/u2f_util_t.c
+++ b/tests/u2f/u2f_util_t.c
@@ -65,6 +65,7 @@ static int hid_read_timeout(void *dev, uint8_t *r, size_t r_len, int to)
 static int TEST_LIVE_DEVICE = 0;
 
 #ifdef __APPLE__
+#ifndef CLOCK_MONOTONIC
 // Implement something compatible w/ linux clock_gettime()
 #include <mach/mach_time.h>
 #define CLOCK_MONOTONIC 0
@@ -83,6 +84,7 @@ static void clock_gettime(int which, struct timespec *ts)
     ts->tv_sec = nano * 1e-9;
     ts->tv_nsec = nano - (ts->tv_sec * 1e9);
 }
+#endif
 #endif  // __APPLE__
 
 


### PR DESCRIPTION
The PR does:
* Always backup the U2F seed on the SDCard in a new file with name `<filename>.u2f` if filename did use a `.pdf` extension. Otherwise (other file extension or no extension), it just appends `.u2f`.
* Backup erase (single file) will always try to erase the `.u2f` file as well
* `seed` with source `backup` will look for a possible `.u2f` filename and tries to set that as u2f seed
** `seed` allows `backupwallet` as source where only the wallet seed will be used (u2f untouched)
** `seed` allows `backupu2f` as source where only the u2f will be ignore (wallet untouched)

What it not does:
* Backup `check` does not verify the u2f seed
* Backup `list` does list all files (also the u2f ones, consuming app must take care of a possible hiding of .u2f files)