### PR TITLE
access to www.myetherwallet.com

### DIFF
--- a/src/u2f_device.h
+++ b/src/u2f_device.h
@@ -2,7 +2,7 @@
 
  The MIT License (MIT)
 
- Copyright (c) 2016 Douglas J. Bakkum, Shift Devices AG
+ Copyright (c) 2016-2017 Douglas J. Bakkum, Shift Devices AG
 
  Permission is hereby granted, free of charge, to any person obtaining
  a copy of this software and associated documentation files (the "Software"),
@@ -35,7 +35,10 @@
 #include "u2f/u2f.h"
 
 
-extern const uint8_t U2F_HIJACK_CODE[U2F_NONCE_LENGTH];
+#define U2F_HIJACK_ORIGIN_TOTAL 2
+
+
+extern const uint8_t U2F_HIJACK_CODE[U2F_HIJACK_ORIGIN_TOTAL][U2F_NONCE_LENGTH];
 
 
 void u2f_send_message(const uint8_t *data, const uint32_t len);

--- a/tests/api.h
+++ b/tests/api.h
@@ -2,7 +2,7 @@
 
  The MIT License (MIT)
 
- Copyright (c) 2015-2016 Douglas J. Bakkum
+ Copyright (c) 2015-2017 Douglas J. Bakkum
 
  Permission is hereby granted, free of charge, to any person obtaining
  a copy of this software and associated documentation files (the "Software"),
@@ -54,7 +54,7 @@ static hid_device *HID_HANDLE;
 static const char tests_pwd[] = "0000";
 static const char hidden_pwd[] = "hide";
 static char command_sent[COMMANDER_REPORT_SIZE] = {0};
-const uint8_t U2F_HIJACK_CODE[U2F_NONCE_LENGTH];// extern
+const uint8_t U2F_HIJACK_CODE[U2F_HIJACK_ORIGIN_TOTAL][U2F_NONCE_LENGTH];// extern
 static unsigned char HID_REPORT[HID_REPORT_SIZE] = {0};
 static char decrypted_report[COMMANDER_REPORT_SIZE];
 


### PR DESCRIPTION
... via u2f_hijack. 

The website origin is part of the hashed U2F client data to be matched by `U2F_HIJACK_CODE`. A beneficial consequence is that the u2f_hijack interface works for specified websites and will not work for fake or phishing websites.