### PR TITLE
set max limit to number of blink sets for mobile pairing

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -735,7 +735,8 @@ static int commander_process_ecdh(int cmd, const uint8_t *pair_pubkey,
         // Xor ECDH secret
         ecdh_secret[i % sizeof(ecdh_secret)] ^= rand_led;
         i++;
-    } while (touch_button_press(DBB_TOUCH_REJECT_TIMEOUT) == DBB_ERR_TOUCH_TIMEOUT);
+    } while ((touch_button_press(DBB_TOUCH_REJECT_TIMEOUT) == DBB_ERR_TOUCH_TIMEOUT) &&
+             (i < LED_MAX_BLINK_SETS));
 
     if (i == 0) {
         // While loop not entered

--- a/src/led.h
+++ b/src/led.h
@@ -33,6 +33,7 @@
 
 
 #define LED_MAX_CODE_BLINKS 4
+#define LED_MAX_BLINK_SETS  6
 
 
 void led_on(void);


### PR DESCRIPTION
This improves the UX by avoiding user confusion on how to end the blink code pairing.