### PR TITLE
shrink bootloader size

### DIFF
--- a/py/pad_boot_binary.py
+++ b/py/pad_boot_binary.py
@@ -12,6 +12,7 @@ max_binsize = 32768
 
 if binsize > max_binsize:
     print '\nERROR: Bootloader must be less than {} bytes.\n'.format(max_binsize)
+    sys.exit(1)
 else:
     shutil.copyfile(binfile, padfile)
     with open(padfile, 'ab') as f:

--- a/py/pad_boot_binary.py
+++ b/py/pad_boot_binary.py
@@ -9,9 +9,10 @@ padfile = sys.argv[2]
 binsize = os.stat(binfile).st_size
 
 max_binsize = 32768
+min_padsize = 32 # Reserved amount for 'factory' entropy
 
-if binsize > max_binsize:
-    print '\nERROR: Bootloader must be less than {} bytes.\n'.format(max_binsize)
+if binsize > max_binsize - min_padsize:
+    print '\nERROR: Bootloader must be less than {} bytes.\n'.format(max_binsize - min_padsize)
     sys.exit(1)
 else:
     shutil.copyfile(binfile, padfile)

--- a/src/startup.c
+++ b/src/startup.c
@@ -30,9 +30,9 @@
 #include "mcu.h"
 #include "led.h"
 #include "usb.h"
+#include "sha2.h"
 #include "flags.h"
 #include "touch.h"
-#include "random.h"
 #include "systick.h"
 #include "bootloader.h"
 #include "board_com.h"
@@ -128,14 +128,17 @@ static void mpu_init(void)
 
 int main(void)
 {
+    uint8_t rnd[SHA256_BLOCK_LENGTH];
+
     wdt_disable(WDT);
     irq_initialize_vectors();
     cpu_irq_enable();
     sysclk_init();
     board_com_init();
-    __stack_chk_guard = random_uint32(0);
     flash_init(FLASH_ACCESS_MODE_128, 6);
     flash_enable_security_bit();
+    sha256_Raw((uint8_t *)(FLASH_BOOT_START + FLASH_BOOT_LEN / 2), FLASH_BOOT_LEN / 2, rnd);
+    memcpy((uint8_t *)__stack_chk_guard, rnd, sizeof(__stack_chk_guard));
     pmc_enable_periph_clk(ID_PIOA);
     delay_init(F_CPU);
     systick_init();


### PR DESCRIPTION
#189 (adding SPI and TWI modes) caused the bootloader to be bigger than allocated 32kB. 

This should have been caught by Travis CI (fixed here). The bootloader used SPI/TWI to get a random number for the stack smashing guard variable. The random number can be instead taken from the factory-installed entropy bytes programmed in flash.