### PR TITLE
Simulate SD card in unit testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
           make test;
       fi;
     - if [ "$TEST" = "yes" ] && [ "${CC}" = "gcc" ]; then
-          valgrind --leak-check=full --num-callers=40 --error-exitcode=1 bin/tests_api;
+          valgrind --leak-check=full --num-callers=40 --suppressions=../.valgrind.supp --error-exitcode=1 bin/tests_api;
       fi;
     - if [ "$TEST" = "yes" ] && [ "${CC}" = "gcc" ]; then
           valgrind --leak-check=full --num-callers=40 --error-exitcode=1 bin/tests_u2f_hid;

--- a/.valgrind.supp
+++ b/.valgrind.supp
@@ -1,0 +1,23 @@
+# Valgrind suppression file
+#
+# Note: Could not figure out how to fix this error. Suppressed instead as it only affects unit testing (simulating the SD card).
+{
+   SUPPRESS (travis): Conditional jump or move depends on uninitialised value(s)/sd.c[TESTING=true]>sd_list>opendir()
+   Memcheck:Cond
+   fun:vfprintf
+   fun:vsnprintf
+   fun:snprintf
+   fun:tests_seed_xpub_backup
+   fun:run_utests
+   fun:main
+}
+{
+   SUPPRESS (ubuntu): Conditional jump or move depends on uninitialised value(s)/sd.c[TESTING=true]>sd_list>opendir()
+   Memcheck:Cond
+   fun:vfprintf
+   fun:__vsnprintf_chk
+   fun:__snprintf_chk
+   fun:tests_seed_xpub_backup
+   fun:run_utests
+   fun:main
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ set(DBB-FIRMWARE-SOURCES
         sha2.c
         u2f_device.c
         usb.c
+        sd.c
 )
 
 if(USE_SECP256K1_LIB)
@@ -44,17 +45,13 @@ set(DBB-BOOTLOADER-SOURCES
         uECC.c
         sha2.c
         utils.c
-        touch.c
         flags.c
-        random.c
-        ataes132.c
         usb.c
 )
 
 set(DBB-HARDWARE-SOURCES
         board_com.c
         ataes132.c
-        sd.c
         systick.c
         touch.c
 )

--- a/src/commander.c
+++ b/src/commander.c
@@ -41,10 +41,10 @@
 #include "aes.h"
 #include "led.h"
 #include "ecc.h"
+#include "sd.h"
 #ifndef TESTING
 #include "touch.h"
 #include "mcu.h"
-#include "sd.h"
 #else
 #include "sham.h"
 #endif

--- a/src/flags.h
+++ b/src/flags.h
@@ -54,7 +54,7 @@
 #define COMMANDER_ARRAY_ELEMENT_MAX 1024
 #define COMMANDER_MAX_ATTEMPTS      15// max PASSWORD or LOCK PIN attempts before device reset
 #define COMMANDER_TOUCH_ATTEMPTS    10// number of attempts until touch button hold required to login
-#define VERIFYPASS_FILENAME         "verification.txt"
+#define VERIFYPASS_FILENAME         "verification.pdf"
 #define VERIFYPASS_CRYPT_TEST       "Digital Bitbox 2FA"
 #define VERIFYPASS_LOCK_CODE_LEN    16// bytes
 #define DEVICE_DEFAULT_NAME         "My Digital Bitbox"

--- a/src/sham.c
+++ b/src/sham.c
@@ -30,82 +30,12 @@
 
 #include "sham.h"
 #include "flags.h"
-#include "utils.h"
 #include "commander.h"
 
-
-static char sd_filename[64] = {0};
-static char sd_text[512] = {0};
 
 void delay_ms(int delay)
 {
     (void) delay;
-}
-
-
-uint8_t sd_write(const char *fn, const char *t, const char *name, uint8_t replace,
-                 int cmd)
-{
-    (void) replace;
-    (void) cmd;
-    memset(sd_filename, 0, sizeof(sd_filename));
-    memset(sd_text, 0, sizeof(sd_text));
-    snprintf(sd_filename, sizeof(sd_filename), "%.*s", (int)strlens(fn), fn);
-    snprintf(sd_text, sizeof(sd_text), "%.*s%c%s", (int)strlens(t), t, BACKUP_DELIM, name);
-    commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
-    return DBB_OK;
-}
-
-
-char *sd_load(const char *fn, int cmd)
-{
-    (void) cmd;
-    static char text[sizeof(sd_text)];
-    memcpy(text, sd_text, sizeof(sd_text));
-    commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
-    if (!strncmp(sd_filename, fn, strlens(fn))) {
-        return text;
-    }
-    return NULL;
-}
-
-
-uint8_t sd_list(int cmd)
-{
-    commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
-    if (sd_filename[0]) {
-        commander_fill_report(cmd_str(cmd), sd_filename, DBB_OK);
-    }
-    return DBB_OK;
-}
-
-
-uint8_t sd_card_inserted(void)
-{
-    commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
-    return DBB_OK;
-}
-
-
-uint8_t sd_file_exists(const char *fn)
-{
-    (void) fn;
-    commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
-    if (!strncmp(sd_filename, fn, strlens(fn))) {
-        return DBB_OK;
-    }
-    return DBB_ERROR;
-}
-
-
-uint8_t sd_erase(int cmd, const char *fn)
-{
-    (void) cmd;
-    (void) fn;
-    commander_fill_report(cmd_str(CMD_sham), flag_msg(DBB_WARN_NO_MCU), DBB_OK);
-    memset(sd_filename, 0, sizeof(sd_filename));
-    memset(sd_text, 0, sizeof(sd_text));
-    return DBB_OK;
 }
 
 

--- a/src/sham.h
+++ b/src/sham.h
@@ -33,13 +33,6 @@
 
 
 void delay_ms(int delay);
-char *sd_load(const char *f, int cmd);
-uint8_t sd_write(const char *f, const char *t, const char *name, uint8_t replace,
-                 int cmd);
-uint8_t sd_list(int cmd);
-uint8_t sd_card_inserted(void);
-uint8_t sd_file_exists(const char *fn);
-uint8_t sd_erase(int cmd, const char *fn);
 uint8_t touch_button_press(uint8_t touch_type);
 uint8_t flash_read_unique_id(uint32_t *serial, uint32_t len);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,6 +67,9 @@ else()
     target_link_libraries(tests_api bitbox hidapi)
 endif()
 
+# Location for sham SD files
+execute_process(COMMAND mkdir "-p" "digitalbitbox" WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
 
 #-----------------------------------------------------------------------------
 # Build tests_u2f_hid

--- a/tests/api.h
+++ b/tests/api.h
@@ -155,7 +155,7 @@ static int api_hid_send_frames(uint32_t cid, uint8_t cmd, const void *data, size
     if (size > COMMANDER_REPORT_SIZE) {
         u_print_error("ERROR  - %s() - Line %d\n", __func__, __LINE__);
         u_print_error("\tCommand size exceeds buffer size by %lu bytes.\n",
-                      size - COMMANDER_REPORT_SIZE);
+                      (unsigned long)size - COMMANDER_REPORT_SIZE);
         return 0;
     }
 

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -53,10 +53,10 @@ static void tests_seed_xpub_backup(void)
     char key[] = "password";
     char xpub0[112], xpub1[112], *echo;
     char seed_usb[512], seed_c[512], seed_b[512], back[512], check[512], erase_file[512];
-    char filename[] = "tests_backup.txt";
-    char filename2[] = "tests_backup2.txt";
-    char filename_create[] = "tests_backup_c.txt";
-    char filename_bad[] = "tests_backup_bad<.txt";
+    char filename[] = "tests_backup.pdf";
+    char filename2[] = "tests_backup2.pdf";
+    char filename_create[] = "tests_backup_c.pdf";
+    char filename_bad[] = "tests_backup_bad<.pdf";
     char keypath[] = "m/44\'/0\'/";
     char seed_create[] =
         "{\"source\":\"create\", \"filename\":\"seed_create.pdf\", \"key\":\"password\"}";
@@ -120,9 +120,7 @@ static void tests_seed_xpub_backup(void)
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), KEY_STANDARD);
     u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_error));
     u_assert_str_has_not(api_read_decrypted_report(), filename_create);
-    if (TEST_LIVE_DEVICE) {
-        u_assert_str_has_not(api_read_decrypted_report(), flag_msg(DBB_ERR_SD_ERASE));
-    }
+    u_assert_str_has_not(api_read_decrypted_report(), flag_msg(DBB_ERR_SD_ERASE));
 
     api_format_send_cmd(cmd_str(CMD_backup), back, KEY_STANDARD);
     u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_error));
@@ -189,43 +187,39 @@ static void tests_seed_xpub_backup(void)
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), KEY_STANDARD);
     u_assert_str_has(api_read_decrypted_report(), "seed_create.pdf");
 
-    if (TEST_LIVE_DEVICE) {
-        api_format_send_cmd(cmd_str(CMD_seed), seed_create_bad, KEY_STANDARD);
-        u_assert_str_has(api_read_decrypted_report(), flag_msg(DBB_ERR_SD_BAD_CHAR));
+    api_format_send_cmd(cmd_str(CMD_seed), seed_create_bad, KEY_STANDARD);
+    u_assert_str_has(api_read_decrypted_report(), flag_msg(DBB_ERR_SD_BAD_CHAR));
 
-        api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), KEY_STANDARD);
-        u_assert_str_has_not(api_read_decrypted_report(), "../seed_create_bad.pdf");
-    }
+    api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), KEY_STANDARD);
+    u_assert_str_has_not(api_read_decrypted_report(), "../seed_create_bad.pdf");
 
     // test sd list overflow
-    if (TEST_LIVE_DEVICE) {
-        char long_backup_name[SD_FILEBUF_LEN_MAX / 8];
-        char lbn[SD_FILEBUF_LEN_MAX / 8];
-        size_t i;
+    char long_backup_name[SD_FILEBUF_LEN_MAX / 8];
+    char lbn[SD_FILEBUF_LEN_MAX / 8];
+    size_t i;
 
-        memset(long_backup_name, '-', sizeof(long_backup_name));
+    memset(long_backup_name, '-', sizeof(long_backup_name));
 
-        for (i = 0; i < SD_FILEBUF_LEN_MAX / sizeof(long_backup_name); i++) {
-            snprintf(lbn, sizeof(lbn), "%lu%s", i, long_backup_name);
-            snprintf(back, sizeof(back), "{\"filename\":\"%s\", \"key\":\"password\"}", lbn);
-            api_format_send_cmd(cmd_str(CMD_backup), back, KEY_STANDARD);
-            u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_error));
-
-            api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), KEY_STANDARD);
-            u_assert_str_has_not(api_read_decrypted_report(), cmd_str(CMD_warning));
-        }
-
-        snprintf(lbn, sizeof(lbn), "%lu%s", i, long_backup_name);
+    for (i = 0; i < SD_FILEBUF_LEN_MAX / sizeof(long_backup_name); i++) {
+        snprintf(lbn, sizeof(lbn), "%lu%s", (unsigned long)i, long_backup_name);
         snprintf(back, sizeof(back), "{\"filename\":\"%s\", \"key\":\"password\"}", lbn);
         api_format_send_cmd(cmd_str(CMD_backup), back, KEY_STANDARD);
         u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_error));
 
         api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), KEY_STANDARD);
-        u_assert_str_has(api_read_decrypted_report(), cmd_str(CMD_warning));
-
-        api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), KEY_STANDARD);
-        u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_error));
+        u_assert_str_has_not(api_read_decrypted_report(), cmd_str(CMD_warning));
     }
+
+    snprintf(lbn, sizeof(lbn), "%lu%s", (unsigned long)i, long_backup_name);
+    snprintf(back, sizeof(back), "{\"filename\":\"%s\", \"key\":\"password\"}", lbn);
+    api_format_send_cmd(cmd_str(CMD_backup), back, KEY_STANDARD);
+    u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_error));
+
+    api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), KEY_STANDARD);
+    u_assert_str_has(api_read_decrypted_report(), cmd_str(CMD_warning));
+
+    api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), KEY_STANDARD);
+    u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_error));
 
     // test keypath
     api_format_send_cmd(cmd_str(CMD_xpub), "m/111", KEY_STANDARD);
@@ -264,16 +258,14 @@ static void tests_seed_xpub_backup(void)
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), KEY_STANDARD);
     u_assert_str_has_not(api_read_decrypted_report(), filename);
 
-    if (TEST_LIVE_DEVICE) {
-        snprintf(back, sizeof(back), "{\"filename\":\"%s\", \"key\":\"password\"}", filename_bad);
-        api_format_send_cmd(cmd_str(CMD_backup), back, KEY_STANDARD);
-        u_assert_str_has(api_read_decrypted_report(), flag_msg(DBB_ERR_SD_BAD_CHAR));
+    snprintf(back, sizeof(back), "{\"filename\":\"%s\", \"key\":\"password\"}", filename_bad);
+    api_format_send_cmd(cmd_str(CMD_backup), back, KEY_STANDARD);
+    u_assert_str_has(api_read_decrypted_report(), flag_msg(DBB_ERR_SD_BAD_CHAR));
 
-        snprintf(check, sizeof(check), "{\"check\":\"%s\", \"key\":\"password\"}", filename_bad);
-        api_format_send_cmd(cmd_str(CMD_backup), check, KEY_STANDARD);
-        u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_success));
-        u_assert_str_has(api_read_decrypted_report(), flag_msg(DBB_ERR_SD_BAD_CHAR));
-    }
+    snprintf(check, sizeof(check), "{\"check\":\"%s\", \"key\":\"password\"}", filename_bad);
+    api_format_send_cmd(cmd_str(CMD_backup), check, KEY_STANDARD);
+    u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_success));
+    u_assert_str_has(api_read_decrypted_report(), flag_msg(DBB_ERR_SD_BAD_CHAR));
 
     snprintf(back, sizeof(back), "{\"filename\":\"%s\", \"key\":\"password\"}", filename);
     api_format_send_cmd(cmd_str(CMD_backup), back, KEY_STANDARD);
@@ -292,9 +284,7 @@ static void tests_seed_xpub_backup(void)
     u_assert_str_not_eq(xpub0, xpub1);
 
     api_format_send_cmd(cmd_str(CMD_backup), check, KEY_STANDARD);
-    if (TEST_LIVE_DEVICE) {
-        u_assert_str_has(api_read_decrypted_report(), flag_msg(DBB_ERR_SD_NO_MATCH));
-    }
+    u_assert_str_has(api_read_decrypted_report(), flag_msg(DBB_ERR_SD_NO_MATCH));
 
     // test cannot overwrite existing backup file
     api_format_send_cmd(cmd_str(CMD_seed), seed_create_2, KEY_STANDARD);
@@ -312,15 +302,14 @@ static void tests_seed_xpub_backup(void)
 
     snprintf(erase_file, sizeof(erase_file), "{\"%s\":\"%s\"}", attr_str(ATTR_erase),
              filename);
+
     api_format_send_cmd(cmd_str(CMD_backup), erase_file, KEY_STANDARD);
     u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_error));
 
-    if (TEST_LIVE_DEVICE) {
-        snprintf(erase_file, sizeof(erase_file), "{\"%s\":\"%s\"}", attr_str(ATTR_erase),
-                 filename_bad);
-        api_format_send_cmd(cmd_str(CMD_backup), erase_file, KEY_STANDARD);
-        u_assert_str_has(api_read_decrypted_report(), flag_msg(DBB_ERR_SD_BAD_CHAR));
-    }
+    snprintf(erase_file, sizeof(erase_file), "{\"%s\":\"%s\"}", attr_str(ATTR_erase),
+             filename_bad);
+    api_format_send_cmd(cmd_str(CMD_backup), erase_file, KEY_STANDARD);
+    u_assert_str_has(api_read_decrypted_report(), flag_msg(DBB_ERR_SD_BAD_CHAR));
 
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), KEY_STANDARD);
     u_assert_str_has_not(api_read_decrypted_report(), filename);
@@ -361,16 +350,14 @@ static void tests_seed_xpub_backup(void)
     u_assert_str_not_eq(xpub0, xpub1);
 
     // load backup
-    if (TEST_LIVE_DEVICE) {
-        api_format_send_cmd(cmd_str(CMD_seed), seed_b, KEY_STANDARD);
-        u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_error));
+    api_format_send_cmd(cmd_str(CMD_seed), seed_b, KEY_STANDARD);
+    u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_error));
 
-        // verify xpub matches
-        api_format_send_cmd(cmd_str(CMD_xpub), "m/0", KEY_STANDARD);
-        u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_error));
-        memcpy(xpub1, api_read_value(CMD_xpub), sizeof(xpub1));
-        u_assert_str_eq(xpub0, xpub1);
-    }
+    // verify xpub matches
+    api_format_send_cmd(cmd_str(CMD_xpub), "m/0", KEY_STANDARD);
+    u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_error));
+    memcpy(xpub1, api_read_value(CMD_xpub), sizeof(xpub1));
+    u_assert_str_eq(xpub0, xpub1);
 
 
     // clean up sd card
@@ -630,7 +617,7 @@ static void tests_device(void)
     api_format_send_cmd(cmd_str(CMD_backup), "{\"key\":\"password\"}", KEY_STANDARD);
     u_assert_str_has(api_read_decrypted_report(), flag_msg(DBB_ERR_IO_INVALID_CMD));
 
-    api_format_send_cmd(cmd_str(CMD_backup), "{\"filename\":\"b.txt\"}", KEY_STANDARD);
+    api_format_send_cmd(cmd_str(CMD_backup), "{\"filename\":\"b.pdf\"}", KEY_STANDARD);
     u_assert_str_has(api_read_decrypted_report(), flag_msg(DBB_ERR_SD_KEY));
 
     api_format_send_cmd(cmd_str(CMD_random), "", KEY_STANDARD);
@@ -659,7 +646,7 @@ static void tests_device(void)
     api_format_send_cmd(cmd_str(CMD_verifypass), attr_str(ATTR_create), KEY_STANDARD);
     u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_error));
 
-    api_format_send_cmd(cmd_str(CMD_backup), "{\"filename\":\"b.txt\", \"key\":\"password\"}",
+    api_format_send_cmd(cmd_str(CMD_backup), "{\"filename\":\"b.pdf\", \"key\":\"password\"}",
                         KEY_STANDARD);
     u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_error));
 
@@ -673,7 +660,7 @@ static void tests_device(void)
     api_format_send_cmd(cmd_str(CMD_verifypass), attr_str(ATTR_create), KEY_STANDARD);
     u_assert_str_has(api_read_decrypted_report(), flag_msg(DBB_ERR_IO_LOCKED));
 
-    api_format_send_cmd(cmd_str(CMD_backup), "{\"filename\":\"b.txt\", \"key\":\"password\"}",
+    api_format_send_cmd(cmd_str(CMD_backup), "{\"filename\":\"b.pdf\", \"key\":\"password\"}",
                         KEY_STANDARD);
     u_assert_str_has(api_read_decrypted_report(), flag_msg(DBB_ERR_IO_LOCKED));
 
@@ -1426,6 +1413,10 @@ static void tests_sign(void)
     char seed[] =
         "{\"key\":\"key\", \"source\":\"create\", \"entropy\":\"entropy_rawH13ucR3\", \"raw\":\"true\", \"filename\":\"s.pdf\"}";
     api_format_send_cmd(cmd_str(CMD_seed), seed, KEY_STANDARD);
+    u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_error));
+
+    // remove backup file to keep SD card clean
+    api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), KEY_STANDARD);
     u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_error));
 
 


### PR DESCRIPTION
Simulating the SD card in unit tests (using FILE calls) allows more comprehensive testing of the backup function, including pdf creation and parsing.