### PR TITLE
U2F backup/load/reset

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -332,6 +332,13 @@ static void commander_process_name(yajl_val json_node)
 {
     const char *path[] = { cmd_str(CMD_name), NULL };
     const char *value = YAJL_GET_STRING(yajl_tree_get(json_node, path, yajl_t_string));
+
+    if (strlens(value) &&
+            utils_limit_alphanumeric_hyphen_underscore_period(value) != DBB_OK) {
+        commander_fill_report(cmd_str(CMD_name), NULL, DBB_ERR_SD_BAD_CHAR);
+        return;
+    }
+
     commander_fill_report(cmd_str(CMD_name), (char *)memory_name(value), DBB_OK);
 }
 

--- a/src/commander.c
+++ b/src/commander.c
@@ -310,13 +310,6 @@ static void commander_process_reset(yajl_val json_node)
         return;
     }
 
-    if (!strncmp(value, attr_str(ATTR_U2F), strlens(attr_str(ATTR_U2F)))) {
-        memory_reset_u2f();
-        commander_clear_report();
-        commander_fill_report(cmd_str(CMD_reset), attr_str(ATTR_success), DBB_OK);
-        return;
-    }
-
     if (!strncmp(value, attr_str(ATTR___ERASE__), strlens(attr_str(ATTR___ERASE__)))) {
         memory_reset_hww();
         commander_clear_report();
@@ -349,141 +342,211 @@ static int commander_process_aes_key(const char *message, int msg_len, PASSWORD_
 }
 
 
-static int commander_process_backup_check(const char *key, const char *filename)
+static int commander_process_backup_check(const char *key, const char *filename,
+        const char *source)
 {
     int ret;
     HDNode node;
-    uint8_t backup[MEM_PAGE_LEN];
-    char *backup_hex = sd_load(filename, CMD_backup);
+    uint8_t backup_hww[MEM_PAGE_LEN];
+    uint8_t backup_u2f[MEM_PAGE_LEN];
+    char *backup_u2f_hex;
+    char *backup_hex;
 
-    if (strlens(backup_hex)) {
+    if (!strlens(source)) {
+        commander_fill_report(cmd_str(CMD_backup), NULL, DBB_ERR_IO_INVALID_CMD);
+        return DBB_ERROR;
+    }
 
-        if (strlens(backup_hex) < MEM_PAGE_LEN * 2) {
+    if (
+        (strcmp(source, attr_str(ATTR_U2F)) != 0) &&
+        (strcmp(source, attr_str(ATTR_HWW)) != 0) &&
+        (strcmp(source, attr_str(ATTR_all)) != 0)) {
+        commander_fill_report(cmd_str(CMD_backup), NULL, DBB_ERR_IO_INVALID_CMD);
+        return DBB_ERROR;
+    }
+
+    backup_hex = sd_load(filename, CMD_backup);
+
+    if (strlens(backup_hex) < MEM_PAGE_LEN * 2) {
+        if (strlens(backup_hex)) {
             commander_fill_report(cmd_str(CMD_backup), NULL, DBB_ERR_SD_NO_MATCH);
+        } // else error reported in sd_load()
+        utils_zero(backup_hex, strlens(backup_hex));
+        return DBB_ERROR;
+    }
+
+    // u2f | all
+    if (strcmp(source, attr_str(ATTR_U2F)) == 0 || strcmp(source, attr_str(ATTR_all)) == 0) {
+        backup_u2f_hex = strchr(backup_hex, SD_PDF_DELIM2);
+        if (!strlens(backup_u2f_hex)) {
             ret = DBB_ERROR;
+        } else {
+            memcpy(backup_u2f, utils_hex_to_uint8(backup_u2f_hex + strlens(SD_PDF_DELIM2_S)),
+                   sizeof(backup_u2f));
+            ret = memcmp(backup_u2f, memory_master_u2f(NULL), MEM_PAGE_LEN) ? DBB_ERROR : DBB_OK;
         }
+    } else {
+        ret = DBB_OK;
+    }
 
-        memcpy(backup, utils_hex_to_uint8(backup_hex), sizeof(backup));
-
-        if (!memcmp(backup, MEM_PAGE_ERASE, MEM_PAGE_LEN)) {
-            commander_fill_report(cmd_str(CMD_backup), NULL, DBB_ERR_SD_NO_MATCH);
+    // hww | all
+    if ((ret == DBB_OK) && (strcmp(source, attr_str(ATTR_HWW)) == 0 ||
+                            strcmp(source, attr_str(ATTR_all)) == 0)) {
+        memcpy(backup_hww, utils_hex_to_uint8(backup_hex), sizeof(backup_hww));
+        if (!memcmp(backup_hww, MEM_PAGE_ERASE, MEM_PAGE_LEN)) {
             ret = DBB_ERROR;
-        } else if (memcmp(backup, memory_master_hww_entropy(NULL), MEM_PAGE_LEN)) {
-            commander_fill_report(cmd_str(CMD_backup), NULL, DBB_ERR_SD_NO_MATCH);
+        } else if (memcmp(backup_hww, memory_master_hww_entropy(NULL), MEM_PAGE_LEN)) {
             ret = DBB_ERROR;
         } else {
             // entropy matches, check if derived master and chaincodes match
             char seed[MEM_PAGE_LEN * 2 + 1];
-            snprintf(seed, sizeof(seed), "%s", utils_uint8_to_hex(backup, MEM_PAGE_LEN));
+            snprintf(seed, sizeof(seed), "%s", utils_uint8_to_hex(backup_hww, MEM_PAGE_LEN));
             if (wallet_generate_node(key, seed, &node) == DBB_ERROR) {
-                commander_fill_report(cmd_str(CMD_backup), NULL, DBB_ERR_SD_NO_MATCH);
                 ret = DBB_ERROR;
             } else if (memcmp(node.private_key, wallet_get_master(), MEM_PAGE_LEN) ||
                        memcmp(node.chain_code, wallet_get_chaincode(), MEM_PAGE_LEN)) {
-                commander_fill_report(cmd_str(CMD_backup), NULL, DBB_ERR_SD_NO_MATCH);
                 ret = DBB_ERROR;
             } else {
-                commander_fill_report(cmd_str(CMD_backup), attr_str(ATTR_success), DBB_OK);
                 ret = DBB_OK;
             }
             utils_zero(seed, sizeof(seed));
         }
-        utils_zero(backup_hex, strlens(backup_hex));
-        utils_zero(backup, sizeof(backup));
-        utils_zero(&node, sizeof(HDNode));
-    } else {
-        /* error reported in sd_load() */
-        ret = DBB_ERROR;
     }
 
+    utils_zero(backup_hex, strlens(backup_hex));
+    utils_zero(backup_hww, sizeof(backup_hww));
+    utils_zero(backup_u2f, sizeof(backup_u2f));
+    utils_zero(&node, sizeof(HDNode));
+
+    if (ret == DBB_OK) {
+        commander_fill_report(cmd_str(CMD_backup), attr_str(ATTR_success), DBB_OK);
+    } else {
+        commander_fill_report(cmd_str(CMD_backup), NULL, DBB_ERR_SD_NO_MATCH);
+    }
     return ret;
 }
 
 
-static int commander_process_backup_create(const char *key, const char *filename)
+static int commander_process_backup_create(const char *key, const char *filename,
+        const char *source)
 {
     int ret;
-    uint8_t backup[MEM_PAGE_LEN];
-    char backup_hex[MEM_PAGE_LEN * 2 + 1];
+    uint8_t backup_hww[MEM_PAGE_LEN];
+    uint8_t backup_u2f[MEM_PAGE_LEN];
+    char backup_hww_hex[MEM_PAGE_LEN * 2 + 1];
+    char backup_u2f_hex[MEM_PAGE_LEN * 2 + 1];
     char *name = (char *)memory_name("");
 
-    memcpy(backup, memory_master_hww_entropy(NULL), MEM_PAGE_LEN);
+    memset(backup_hww_hex, 0, sizeof(backup_hww_hex));
+    memset(backup_u2f_hex, 0, sizeof(backup_u2f_hex));
 
-    if (!memcmp(backup, MEM_PAGE_ERASE, MEM_PAGE_LEN)) {
+    if (wallet_seeded() != DBB_OK) {
         commander_fill_report(cmd_str(CMD_backup), NULL, DBB_ERR_KEY_MASTER);
         return DBB_ERROR;
     }
 
-    snprintf(backup_hex, sizeof(backup_hex), "%s", utils_uint8_to_hex(backup,
-             sizeof(backup)));
+    if (strcmp(source, attr_str(ATTR_HWW)) == 0 || strcmp(source, attr_str(ATTR_all)) == 0) {
+        memcpy(backup_hww, memory_master_hww_entropy(NULL), MEM_PAGE_LEN);
+        snprintf(backup_hww_hex, sizeof(backup_hww_hex), "%s", utils_uint8_to_hex(backup_hww,
+                 sizeof(backup_hww)));
+    }
 
-    ret = sd_write(filename, backup_hex, name, DBB_SD_NO_REPLACE, CMD_backup);
+    if (strcmp(source, attr_str(ATTR_U2F)) == 0 || strcmp(source, attr_str(ATTR_all)) == 0) {
+        memcpy(backup_u2f, memory_report_master_u2f(), MEM_PAGE_LEN);
+        snprintf(backup_u2f_hex, sizeof(backup_u2f_hex), "%s", utils_uint8_to_hex(backup_u2f,
+                 sizeof(backup_u2f)));
+    }
 
-    utils_zero(backup, sizeof(backup));
-    utils_zero(backup_hex, sizeof(backup_hex));
+    ret = sd_write(filename, backup_hww_hex, name, backup_u2f_hex, DBB_SD_NO_REPLACE,
+                   CMD_backup);
+
+    utils_zero(backup_hww, sizeof(backup_hww));
+    utils_zero(backup_hww_hex, sizeof(backup_hww_hex));
+    utils_zero(backup_u2f, sizeof(backup_u2f));
+    utils_zero(backup_u2f_hex, sizeof(backup_u2f_hex));
 
     if (ret != DBB_OK) {
         /* error reported in sd_write() */
         return ret;
     }
 
-    return commander_process_backup_check(key, filename);
+    return commander_process_backup_check(key, filename, source);
 }
 
 
 static void commander_process_backup(yajl_val json_node)
 {
-    const char *filename, *key, *check, *erase, *value;
+    const char *filename_path[] = { cmd_str(CMD_backup), cmd_str(CMD_filename), NULL };
+    const char *source_path[] = { cmd_str(CMD_backup), cmd_str(CMD_source), NULL };
+    const char *value_path[] = { cmd_str(CMD_backup), NULL };
+    const char *erase_path[] = { cmd_str(CMD_backup), cmd_str(CMD_erase), NULL };
+    const char *check_path[] = { cmd_str(CMD_backup), cmd_str(CMD_check), NULL };
+    const char *key_path[] = { cmd_str(CMD_backup), cmd_str(CMD_key), NULL };
+    const char *filename = YAJL_GET_STRING(yajl_tree_get(json_node, filename_path,
+                                           yajl_t_string));
+    const char *source_y = YAJL_GET_STRING(yajl_tree_get(json_node, source_path,
+                                           yajl_t_string));
+    const char *value = YAJL_GET_STRING(yajl_tree_get(json_node, value_path, yajl_t_string));
+    const char *erase = YAJL_GET_STRING(yajl_tree_get(json_node, erase_path, yajl_t_string));
+    const char *check = YAJL_GET_STRING(yajl_tree_get(json_node, check_path, yajl_t_string));
+    const char *key = YAJL_GET_STRING(yajl_tree_get(json_node, key_path, yajl_t_string));
+    char source[MAX(MAX(strlens(attr_str(ATTR_U2F)), strlens(attr_str(ATTR_HWW))),
+                                                         strlens(attr_str(ATTR_all))) + 1];
 
     if (wallet_is_locked()) {
         commander_fill_report(cmd_str(CMD_backup), NULL, DBB_ERR_IO_LOCKED);
         return;
     }
 
-    const char *value_path[] = { cmd_str(CMD_backup), NULL };
-    value = YAJL_GET_STRING(yajl_tree_get(json_node, value_path, yajl_t_string));
-
-    if (value) {
+    if (strlens(value)) {
         if (strcmp(value, attr_str(ATTR_list)) == 0) {
             sd_list(CMD_backup);
             return;
         }
 
         if (strcmp(value, attr_str(ATTR_erase)) == 0) {
+            // Erase all files
             sd_erase(CMD_backup, NULL);
             return;
         }
     }
 
-    const char *erase_path[] = { cmd_str(CMD_backup), cmd_str(CMD_erase), NULL };
-    erase = YAJL_GET_STRING(yajl_tree_get(json_node, erase_path, yajl_t_string));
-
-    if (erase) {
+    if (strlens(erase)) {
+        // Erase single file
         sd_erase(CMD_backup, erase);
         return;
     }
 
-    const char *key_path[] = { cmd_str(CMD_backup), cmd_str(CMD_key), NULL };
-    key = YAJL_GET_STRING(yajl_tree_get(json_node, key_path, yajl_t_string));
-
-    if (strlens(key)) {
-        const char *check_path[] = { cmd_str(CMD_backup), cmd_str(CMD_check), NULL };
-        check = YAJL_GET_STRING(yajl_tree_get(json_node, check_path, yajl_t_string));
-
-        if (check) {
-            commander_process_backup_check(key, check);
-            return;
-        }
-
-        const char *filename_path[] = { cmd_str(CMD_backup), cmd_str(CMD_filename), NULL };
-        filename = YAJL_GET_STRING(yajl_tree_get(json_node, filename_path, yajl_t_string));
-
-        if (filename) {
-            commander_process_backup_create(key, filename);
-            return;
-        }
+    if (strlens(source_y)) {
+        snprintf(source, sizeof(source), "%s", source_y);
     } else {
+        // Defaults
+        if (check) {
+            snprintf(source, sizeof(source), "%s", attr_str(ATTR_HWW));// Backward compatible
+        } else {
+            snprintf(source, sizeof(source), "%s", attr_str(ATTR_all));
+        }
+    }
+
+    if (!strlens(key) && (strcmp(source, attr_str(ATTR_U2F)) != 0)) {
+        // Exit if backing up HWW but no key given
         commander_fill_report(cmd_str(CMD_seed), NULL, DBB_ERR_SD_KEY);
+        return;
+    }
+
+    if (check) {
+        // Verify existing backup
+        if (strcmp(source, attr_str(ATTR_all)) == 0) {
+            commander_fill_report(cmd_str(CMD_backup), NULL, DBB_ERR_IO_INVALID_CMD);
+            return;
+        }
+        commander_process_backup_check(key, check, source);
+        return;
+    }
+
+    if (filename) {
+        // Create new backup
+        commander_process_backup_create(key, filename, source);
         return;
     }
 
@@ -500,7 +563,7 @@ static void commander_process_seed(yajl_val json_node)
     const char *source_path[] = { cmd_str(CMD_seed), cmd_str(CMD_source), NULL };
     const char *entropy_path[] = { cmd_str(CMD_seed), cmd_str(CMD_entropy), NULL };
     const char *filename_path[] = { cmd_str(CMD_seed), cmd_str(CMD_filename), NULL };
-
+    const char *u2f_counter_path[] = { cmd_str(CMD_seed), cmd_str(CMD_U2F_counter), NULL };
     const char *key = YAJL_GET_STRING(yajl_tree_get(json_node, key_path, yajl_t_string));
     const char *raw = YAJL_GET_STRING(yajl_tree_get(json_node, raw_path, yajl_t_string));
     const char *source = YAJL_GET_STRING(yajl_tree_get(json_node, source_path,
@@ -509,6 +572,8 @@ static void commander_process_seed(yajl_val json_node)
                                           yajl_t_string));
     const char *filename = YAJL_GET_STRING(yajl_tree_get(json_node, filename_path,
                                            yajl_t_string));
+    yajl_val u2f_counter_data = yajl_tree_get(json_node, u2f_counter_path,
+                                yajl_t_number);
 
     if (wallet_is_locked()) {
         commander_fill_report(cmd_str(CMD_seed), NULL, DBB_ERR_IO_LOCKED);
@@ -520,7 +585,7 @@ static void commander_process_seed(yajl_val json_node)
         return;
     }
 
-    if (!strlens(key)) {
+    if (!strlens(key) && !(strcmp(source, attr_str(ATTR_U2F_load)) == 0)) {
         commander_fill_report(cmd_str(CMD_seed), NULL, DBB_ERR_SD_KEY);
         return;
     }
@@ -537,18 +602,13 @@ static void commander_process_seed(yajl_val json_node)
 
     if (strcmp(source, attr_str(ATTR_create)) == 0) {
         // Generate a new wallet, optionally with entropy entered via USB
-        uint8_t i, add_entropy, number[MEM_PAGE_LEN], entropy_b[MEM_PAGE_LEN];
+        uint8_t i, add_entropy, entropy_b[MEM_PAGE_LEN];
         char entropy_c[MEM_PAGE_LEN * 2 + 1];
 
         memset(entropy_b, 0, sizeof(entropy_b));
 
         if (sd_file_exists(filename) == DBB_OK) {
             commander_fill_report(cmd_str(CMD_seed), NULL, DBB_ERR_SD_OPEN_FILE);
-            return;
-        }
-
-        if (random_bytes(number, sizeof(number), 1) == DBB_ERROR) {
-            commander_fill_report(cmd_str(CMD_seed), NULL, DBB_ERR_MEM_ATAES);
             return;
         }
 
@@ -560,7 +620,7 @@ static void commander_process_seed(yajl_val json_node)
             sha256_Raw((const uint8_t *)entropy, strlens(entropy), entropy_b);
         }
 
-        // add extra entropy from device unless raw is set
+        // Add extra entropy from device unless raw is set
         add_entropy = 1;
         if (strlens(entropy) && strlens(raw)) {
             if (!strcmp(raw, attr_str(ATTR_true))) {
@@ -569,6 +629,11 @@ static void commander_process_seed(yajl_val json_node)
         }
 
         if (add_entropy) {
+            uint8_t number[MEM_PAGE_LEN];
+            if (random_bytes(number, sizeof(number), 1) == DBB_ERROR) {
+                commander_fill_report(cmd_str(CMD_seed), NULL, DBB_ERR_MEM_ATAES);
+                return;
+            }
             for (i = 0; i < MEM_PAGE_LEN; i++) {
                 entropy_b[i] ^= number[i];
             }
@@ -578,7 +643,7 @@ static void commander_process_seed(yajl_val json_node)
                  sizeof(entropy_b)));
         ret = wallet_generate_master(key, entropy_c);
         if (ret == DBB_OK) {
-            if (commander_process_backup_create(key, filename) != DBB_OK) {
+            if (commander_process_backup_create(key, filename, attr_str(ATTR_all)) != DBB_OK) {
                 memory_erase_hww_seed();
                 return;
             }
@@ -586,29 +651,58 @@ static void commander_process_seed(yajl_val json_node)
 
         utils_zero(entropy_b, sizeof(entropy_b));
         utils_zero(entropy_c, sizeof(entropy_c));
-    } else if (strcmp(source, attr_str(ATTR_backup)) == 0) {
+    }
+
+    else if (strcmp(source, attr_str(ATTR_U2F_create)) == 0) {
+        memory_reset_u2f();
+        ret = commander_process_backup_create(key, filename, attr_str(ATTR_all));
+        if (ret == DBB_OK && YAJL_IS_INTEGER(u2f_counter_data)) {
+            memory_u2f_count_set(YAJL_GET_INTEGER(u2f_counter_data));
+        }
+    }
+
+    else if (strcmp(source, attr_str(ATTR_backup)) == 0 ||
+             strcmp(source, attr_str(ATTR_U2F_load)) == 0) {
         char entropy_c[MEM_PAGE_LEN * 2 + 1];
         char *backup_hex = sd_load(filename, CMD_seed);
-        char *name = strchr(backup_hex, BACKUP_DELIM);
+        char *name = strchr(backup_hex, SD_PDF_DELIM);
+        char *u2f = strchr(backup_hex, SD_PDF_DELIM2);
 
-        if (strlens(backup_hex) < MEM_PAGE_LEN * 2) {
-            ret = DBB_ERROR;
-        } else if (strlens(name) ? (name != MEM_PAGE_LEN * 2 + backup_hex) : 0) {
-            ret = DBB_ERROR;
-        } else if (!strlens(name) ? (strlens(backup_hex) != MEM_PAGE_LEN * 2) : 0) {
-            ret = DBB_ERROR;
-        } else {
-            if (strlens(name) > 1) {
-                memory_name(name + 1);
+        if (strcmp(source, attr_str(ATTR_U2F_load)) == 0) {
+            if (strlens(u2f)) {
+                uint8_t backup_u2f[MEM_PAGE_LEN];
+                memcpy(backup_u2f, utils_hex_to_uint8(u2f + strlens(SD_PDF_DELIM2_S)),
+                       sizeof(backup_u2f));
+                memory_master_u2f(backup_u2f);
+                if (YAJL_IS_INTEGER(u2f_counter_data)) {
+                    memory_u2f_count_set(YAJL_GET_INTEGER(u2f_counter_data));
+                }
+                ret = DBB_OK;
+            } else {
+                ret = DBB_ERROR;
             }
-
-            snprintf(entropy_c, sizeof(entropy_c), "%s", backup_hex);
-            ret = wallet_generate_master(key, entropy_c);
+        } else {
+            if (strlens(backup_hex) < MEM_PAGE_LEN * 2) {
+                ret = DBB_ERROR;
+            } else if (strlens(name) && strlens(u2f) ?
+                       (name != backup_hex + MEM_PAGE_LEN * 4 + strlens(SD_PDF_DELIM2_S)) :
+                       (name != backup_hex + MEM_PAGE_LEN * 2)) {
+                ret = DBB_ERROR;
+            } else if (!strlens(name) ? (strlens(backup_hex) != MEM_PAGE_LEN * 2) : 0) {
+                ret = DBB_ERROR;
+            } else {
+                if (strlens(name) > 1) {
+                    memory_name(name + 1);
+                }
+                snprintf(entropy_c, sizeof(entropy_c), "%s", backup_hex);
+                ret = wallet_generate_master(key, entropy_c);
+            }
         }
-
         utils_zero(backup_hex, strlens(backup_hex));
         utils_zero(entropy_c, sizeof(entropy_c));
-    } else {
+    }
+
+    else {
         commander_fill_report(cmd_str(CMD_seed), NULL, DBB_ERR_IO_INVALID_CMD);
         return;
     }
@@ -789,7 +883,7 @@ static void commander_process_verifypass(yajl_val json_node)
             memcpy(text, utils_uint8_to_hex(memory_report_verification_key(), 32), 64 + 1);
             utils_clear_buffers();
             int ret = sd_write(VERIFYPASS_FILENAME, text, NULL,
-                               DBB_SD_REPLACE, CMD_verifypass);
+                               NULL, DBB_SD_REPLACE, CMD_verifypass);
 
             if (ret == DBB_OK) {
                 l = sd_load(VERIFYPASS_FILENAME, CMD_verifypass);

--- a/src/flags.h
+++ b/src/flags.h
@@ -2,7 +2,7 @@
 
  The MIT License (MIT)
 
- Copyright (c) 2015-2016 Douglas J. Bakkum
+ Copyright (c) 2015-2018 Douglas J. Bakkum
 
  Permission is hereby granted, free of charge, to any person obtaining
  a copy of this software and associated documentation files (the "Software"),
@@ -61,8 +61,6 @@
 #define SD_FILEBUF_LEN_MAX          (COMMANDER_REPORT_SIZE * 4 / 7)
 #define AES_DATA_LEN_MAX            (COMMANDER_REPORT_SIZE * 4 / 7)// base64 increases size by ~4/3; AES encryption by max 32 char
 #define PASSWORD_LEN_MIN            4
-#define BACKUP_DELIM                '-'
-#define BACKUP_DELIM_S              "-"
 
 
 #define _STRINGIFY(S) #S
@@ -119,6 +117,7 @@ X(recid)          \
 X(pin)            \
 X(U2F)            \
 X(U2F_hijack)     \
+X(U2F_counter)    \
 /*  reply keys  */\
 X(ciphertext)     \
 X(echo)           \
@@ -166,7 +165,11 @@ X(serial)         \
 X(version)        \
 X(password)       \
 X(TFA)            \
+X(all)            \
+X(HWW)            \
 X(U2F)            \
+X(U2F_load)       \
+X(U2F_create)     \
 X(U2F_hijack)     \
 X(__ERASE__)      \
 X(__FORCE__)      \

--- a/src/memory.c
+++ b/src/memory.c
@@ -572,6 +572,10 @@ uint32_t memory_u2f_count_iter(void)
     memory_eeprom((uint8_t *)&c, (uint8_t *)&MEM_u2f_count, MEM_U2F_COUNT_ADDR, 4);
     return MEM_u2f_count;
 }
+void memory_u2f_count_set(uint32_t c)
+{
+    memory_eeprom((uint8_t *)&c, (uint8_t *)&MEM_u2f_count, MEM_U2F_COUNT_ADDR, 4);
+}
 uint32_t memory_u2f_count_read(void)
 {
     memory_eeprom(NULL, (uint8_t *)&MEM_u2f_count, MEM_U2F_COUNT_ADDR, 4);

--- a/src/memory.h
+++ b/src/memory.h
@@ -128,6 +128,7 @@ uint16_t memory_pin_err_count(const uint8_t access);
 uint16_t memory_read_pin_err_count(void);
 
 uint32_t memory_u2f_count_iter(void);
+void memory_u2f_count_set(uint32_t c);
 uint32_t memory_u2f_count_read(void);
 
 

--- a/src/sd.h
+++ b/src/sd.h
@@ -2,7 +2,7 @@
 
  The MIT License (MIT)
 
- Copyright (c) 2015-2016 Douglas J. Bakkum
+ Copyright (c) 2015-2018 Douglas J. Bakkum
 
  Permission is hereby granted, free of charge, to any person obtaining
  a copy of this software and associated documentation files (the "Software"),
@@ -32,21 +32,33 @@
 #include <stdint.h>
 
 
+#define SD_PDF_DELIM         '-'
+#define SD_PDF_DELIM_S       "-"
+#define SD_PDF_DELIM2        '='
+#define SD_PDF_DELIM2_S      "="
 #define SD_PDF_LINE_BUF_SIZE 128
 #define SD_PDF_HEAD "%%PDF-1.1\n"//%%\xDB\xDC\xDD\xDE\xDF\n"// uncomment the high-bit ascii characters if storing binary data
 #define SD_PDF_1_0  "1 0 obj\n<</Type /Catalog\n/Pages 2 0 R\n>>\nendobj\n"
 #define SD_PDF_2_0  "2 0 obj\n<</Type /Pages\n/Kids [3 0 R]\n/Count 1\n/MediaBox [0 0 595 842]\n>>\nendobj\n"
 #define SD_PDF_3_0  "3 0 obj\n<</Type /Page\n/Parent 2 0 R\n/Resources\n<</Font\n<</F1\n<</Type /Font\n/BaseFont /Helvetica\n/Subtype /Type1\n>>\n>>\n>>\n/Contents 4 0 R\n>>\nendobj\n"
 #define SD_PDF_4_0_HEAD   "4 0 obj\n<< /Length %i >>\nstream\n"
-#define SD_PDF_BACKUP_START "<20 2020202020> Tj"
-#define SD_PDF_BACKUP_END   "<2020202020 20> Tj"
-#define SD_PDF_TEXT_0     "BT\n/F1 12 Tf\n50 700 Td\n(Wallet backup:) Tj\n" SD_PDF_BACKUP_START "\n0 -24 Td\n("
+#define SD_PDF_TEXT_BEGIN "BT\n/F1 12 Tf\n50 700 Td\n"
+#define SD_PDF_TEXT_NAME  "(Wallet name: "
+#define SD_PDF_TEXT_HWW   ") Tj\n0 -48 Td\n(Wallet backup:) Tj\n0 -24 Td\n("
+#define SD_PDF_TEXT_U2F   ") Tj\n0 -48 Td\n(U2F backup:) Tj\n0 -24 Td\n("
+#define SD_PDF_TEXT_FOOT  ") Tj\n0 -48 Td\n(Passphrase:  ______________________) Tj\n/F1 10 Tf\n0 -96 Td\n(For instructions, see digitalbitbox.com/backup.) Tj\n"
 #define SD_PDF_TEXT_CONT  ") Tj\n0 -16 Td\n("
-#define SD_PDF_TEXT_1     ") Tj\n0 -16 Td\n%%(" BACKUP_DELIM_S
-#define SD_PDF_TEXT_2     ") Tj\n" SD_PDF_BACKUP_END "\n0 -48 Td\n(Wallet name: "
-#define SD_PDF_TEXT_3     ") Tj\n0 -32 Td\n(Passphrase:  ______________________) Tj\n/F1 10 Tf\n0 -60 Td\n(digitalbitbox.com/backup) Tj\nET\n"
-#define SD_PDF_4_0_END    "\nendstream\nendobj\n"
-#define SD_PDF_END        "xref\n0 5\n0000000000 65535 f \n%010i 00000 n \n%010i 00000 n \n%010i 00000 n \n%010i 00000 n \ntrailer\n<<\n/Size 5\n/Root 1 0 R\n>>\nstartxref\n%i\n%%%%%%%%EOF"
+#define SD_PDF_BACKUP_START     "<20 2020202020> Tj\n"
+#define SD_PDF_COMMENT_HEAD     "%%("
+#define SD_PDF_COMMENT_CLOSE    ") Tj\n"
+#define SD_PDF_COMMENT_CONT     SD_PDF_COMMENT_CLOSE SD_PDF_COMMENT_HEAD
+#define SD_PDF_BACKUP_END       "<2020202020 20> Tj\n"
+#define SD_PDF_REDUNDANCY_START "%%(REDUNDANCY_START) Tj\n"
+#define SD_PDF_REDUNDANCY_END   "%%(REDUNCANCY_END) Tj\n"
+#define SD_PDF_TEXT_END   "\nET\n"
+#define SD_PDF_4_0_END    "endstream\nendobj\n"
+#define SD_PDF_END        "xref\n0 5\n0000000000 65535 f \n%010i 00000 n \n%010i 00000 n \n%010i 00000 n \n%010i 00000 n \ntrailer\n<<\n/Size 5\n/Root 1 0 R\n>>\nstartxref\n%i\n"
+#define SD_PDF_EOF        "%%%%EOF"// FIXME - deleted 4 '%' signs - check if ok LIVE testing
 
 
 uint8_t sd_list(int cmd);
@@ -55,7 +67,7 @@ uint8_t sd_file_exists(const char *fn);
 uint8_t sd_erase(int cmd, const char *fn);
 char *sd_load(const char *fn, int cmd);
 uint8_t sd_write(const char *fn, const char *wallet_backup, const char *wallet_name,
-                 uint8_t replace, int cmd);
+                 const char *u2f_backup, uint8_t replace, int cmd);
 
 
 #endif

--- a/tests/api.h
+++ b/tests/api.h
@@ -35,6 +35,8 @@
 #include "u2f/u2f_hid.h"
 #include "u2f/u2f.h"
 #include "u2f_device.h"
+#include "commander.h"
+#include "utest.h"
 #include "usb.h"
 
 

--- a/tests/sd_files/test_backup.pdf
+++ b/tests/sd_files/test_backup.pdf
@@ -1,0 +1,77 @@
+%PDF-1.1
+1 0 obj
+<</Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+2 0 obj
+<</Type /Pages
+/Kids [3 0 R]
+/Count 1
+/MediaBox [0 0 595 842]
+>>
+endobj
+3 0 obj
+<</Type /Page
+/Parent 2 0 R
+/Resources
+<</Font
+<</F1
+<</Type /Font
+/BaseFont /Helvetica
+/Subtype /Type1
+>>
+>>
+>>
+/Contents 4 0 R
+>>
+endobj
+4 0 obj
+<< /Length 816 >>
+stream
+BT
+/F1 12 Tf
+50 700 Td
+(Wallet name: My Digital Bitbox) Tj
+0 -48 Td
+(Wallet backup:) Tj
+0 -24 Td
+(69794a18aef59bdd43b8e4e6831d5403ccd80f150a21b90c6d4499d879707bad) Tj
+0 -48 Td
+(U2F backup:) Tj
+0 -24 Td
+(bcb11d5d22f16b323f64c50b8e6ce7ece69d9a4de45eee6d7c9d000436264ae6) Tj
+0 -48 Td
+(Passphrase:  ______________________) Tj
+/F1 10 Tf
+0 -96 Td
+(For instructions, see digitalbitbox.com/backup.) Tj
+<20 2020202020> Tj
+%(69794a18aef59bdd43b8e4e6831d5403ccd80f150a21b90c6d4499d879707bad) Tj
+%(=bcb11d5d22f16b323f64c50b8e6ce7ece69d9a4de45eee6d7c9d000436264ae6) Tj
+%(-My Digital Bitbox) Tj
+<2020202020 20> Tj
+%(REDUNDANCY_START) Tj
+%(69794a18aef59bdd43b8e4e6831d5403ccd80f150a21b90c6d4499d879707bad) Tj
+%(=bcb11d5d22f16b323f64c50b8e6ce7ece69d9a4de45eee6d7c9d000436264ae6) Tj
+%(=My Digital Bitbox) Tj
+%(REDUNCANCY_END) Tj
+
+ET
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000009 00000 n 
+0000000057 00000 n 
+0000000137 00000 n 
+0000000284 00000 n 
+trailer
+<<
+/Size 5
+/Root 1 0 R
+>>
+startxref
+1150
+%%EOF

--- a/tests/sd_files/test_backup_hww.pdf
+++ b/tests/sd_files/test_backup_hww.pdf
@@ -1,0 +1,75 @@
+%PDF-1.1
+1 0 obj
+<</Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+2 0 obj
+<</Type /Pages
+/Kids [3 0 R]
+/Count 1
+/MediaBox [0 0 595 842]
+>>
+endobj
+3 0 obj
+<</Type /Page
+/Parent 2 0 R
+/Resources
+<</Font
+<</F1
+<</Type /Font
+/BaseFont /Helvetica
+/Subtype /Type1
+>>
+>>
+>>
+/Contents 4 0 R
+>>
+endobj
+4 0 obj
+<< /Length 608 >>
+stream
+BT
+/F1 12 Tf
+50 700 Td
+(Wallet name: My Digital Bitbox) Tj
+0 -48 Td
+(Wallet backup:) Tj
+0 -24 Td
+(69794a18aef59bdd43b8e4e6831d5403ccd80f150a21b90c6d4499d879707bad) Tj
+0 -48 Td
+(U2F backup:) Tj
+0 -24 Td
+() Tj
+0 -48 Td
+(Passphrase:  ______________________) Tj
+/F1 10 Tf
+0 -96 Td
+(For instructions, see digitalbitbox.com/backup.) Tj
+<20 2020202020> Tj
+%(69794a18aef59bdd43b8e4e6831d5403ccd80f150a21b90c6d4499d879707bad) Tj
+%(-My Digital Bitbox) Tj
+<2020202020 20> Tj
+%(REDUNDANCY_START) Tj
+%(69794a18aef59bdd43b8e4e6831d5403ccd80f150a21b90c6d4499d879707bad) Tj
+%(=My Digital Bitbox) Tj
+%(REDUNCANCY_END) Tj
+
+ET
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000009 00000 n 
+0000000057 00000 n 
+0000000137 00000 n 
+0000000284 00000 n 
+trailer
+<<
+/Size 5
+/Root 1 0 R
+>>
+startxref
+942
+%%EOF

--- a/tests/sd_files/test_backup_u2f.pdf
+++ b/tests/sd_files/test_backup_u2f.pdf
@@ -1,0 +1,77 @@
+%PDF-1.1
+1 0 obj
+<</Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+2 0 obj
+<</Type /Pages
+/Kids [3 0 R]
+/Count 1
+/MediaBox [0 0 595 842]
+>>
+endobj
+3 0 obj
+<</Type /Page
+/Parent 2 0 R
+/Resources
+<</Font
+<</F1
+<</Type /Font
+/BaseFont /Helvetica
+/Subtype /Type1
+>>
+>>
+>>
+/Contents 4 0 R
+>>
+endobj
+4 0 obj
+<< /Length 624 >>
+stream
+BT
+/F1 12 Tf
+50 700 Td
+(Wallet name: My Digital Bitbox) Tj
+0 -48 Td
+(Wallet backup:) Tj
+0 -24 Td
+() Tj
+0 -48 Td
+(U2F backup:) Tj
+0 -24 Td
+(bcb11d5d22f16b323f64c50b8e6ce7ece69d9a4de45eee6d7c9d000436264ae6) Tj
+0 -48 Td
+(Passphrase:  ______________________) Tj
+/F1 10 Tf
+0 -96 Td
+(For instructions, see digitalbitbox.com/backup.) Tj
+<20 2020202020> Tj
+%() Tj
+%(=bcb11d5d22f16b323f64c50b8e6ce7ece69d9a4de45eee6d7c9d000436264ae6) Tj
+%(-My Digital Bitbox) Tj
+<2020202020 20> Tj
+%(REDUNDANCY_START) Tj
+%() Tj
+%(=bcb11d5d22f16b323f64c50b8e6ce7ece69d9a4de45eee6d7c9d000436264ae6) Tj
+%(=My Digital Bitbox) Tj
+%(REDUNCANCY_END) Tj
+
+ET
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000009 00000 n 
+0000000057 00000 n 
+0000000137 00000 n 
+0000000284 00000 n 
+trailer
+<<
+/Size 5
+/Root 1 0 R
+>>
+startxref
+958
+%%EOF

--- a/tests/sd_files/test_backup_v2.2.3.pdf
+++ b/tests/sd_files/test_backup_v2.2.3.pdf
@@ -1,0 +1,69 @@
+%PDF-1.1
+1 0 obj
+<</Type /Catalog
+/Pages 2 0 R
+>>
+endobj
+2 0 obj
+<</Type /Pages
+/Kids [3 0 R]
+/Count 1
+/MediaBox [0 0 595 842]
+>>
+endobj
+3 0 obj
+<</Type /Page
+/Parent 2 0 R
+/Resources
+<</Font
+<</F1
+<</Type /Font
+/BaseFont /Helvetica
+/Subtype /Type1
+>>
+>>
+>>
+/Contents 4 0 R
+>>
+endobj
+4 0 obj
+<< /Length 357 >>
+stream
+BT
+/F1 12 Tf
+50 700 Td
+(Wallet backup:) Tj
+<20 2020202020> Tj
+0 -24 Td
+(69794a18aef59bdd43b8e4e6831d5403ccd80f150a21b90c6d4499d879707bad) Tj
+0 -16 Td
+() Tj
+0 -16 Td
+%(-TESTTESTTESTTEST-) Tj
+<2020202020 20> Tj
+0 -48 Td
+(Wallet name: TESTTESTTESTTEST-) Tj
+0 -32 Td
+(Passphrase:  ______________________) Tj
+/F1 10 Tf
+0 -60 Td
+(digitalbitbox.com/backup) Tj
+ET
+
+endstream
+endobj
+xref
+0 5
+0000000000 65535 f 
+0000000009 00000 n 
+0000000057 00000 n 
+0000000137 00000 n 
+0000000284 00000 n 
+trailer
+<<
+/Size 5
+/Root 1 0 R
+>>
+startxref
+691
+%%EOF

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -802,17 +802,17 @@ static void tests_input(void)
     u_assert_str_has(api_read_decrypted_report(), flag_msg(DBB_ERR_IO_JSON_PARSE));
 
     api_send_cmd("{\"name\": \"na\\nme\"}", KEY_STANDARD);
-    u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_error));
+    u_assert_str_has(api_read_decrypted_report(), flag_msg(DBB_ERR_SD_BAD_CHAR));
 
     api_send_cmd("{\"name\": \"na\\r\\\\ \\/ \\f\\b\\tme\\\"\"}", KEY_STANDARD);
-    u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_error));
+    u_assert_str_has(api_read_decrypted_report(), flag_msg(DBB_ERR_SD_BAD_CHAR));
 #endif
 
     api_send_cmd("{\"name\": null}", KEY_STANDARD);
     u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_error));
 
     api_send_cmd("{\"name\": \"na\\u0066me\\ufc00\\u0000\"}", KEY_STANDARD);
-    u_assert_str_has_not(api_read_decrypted_report(), attr_str(ATTR_error));
+    u_assert_str_has(api_read_decrypted_report(), flag_msg(DBB_ERR_SD_BAD_CHAR));
 
     int i;
     for (i = 0; i < COMMANDER_MAX_ATTEMPTS - 1; i++) {


### PR DESCRIPTION
Rationale: The U2F master key is currently not backed up on the micro SD card. 

Goal: Allow back up and recovery of the U2F master key, and allow the possibility for it to be independent of the hardware wallet. The latter is because if one creates a new hardware wallet, one would likely not want to reset U2F because any previously paired websites will no longer be accessible.

Additional changes:
- The PDF file now saves the master seed (and u2f key) 2 extra times (within commented lines inside the PDF) for redundancy against bit corruption. The commented lines are viewable with a text editor.
- The wallet `name` is now limited to alphanumeric_hyphen_underscore_period characters. (This was already being enforced by the desktop client app.)

## API
### BACKUP CREATE NEW
*command*
```
"backup" : 
      "key" : "key",
      "filename" : "filename"
      "source" : "U2F/HWW/all"
```
*reply*
```
"backup" : "success"
```
- `source` is optional for backward compatablity, and defaults to `all`. 
- `key` is optional/ignored if source is `U2F`.


### BACKUP VERIFY
*command*
```
"backup" : 
      "check" : "filename"
      "key" : "key"
      "source" : "U2F/HWW"
```
*reply*
```
"backup" : "success"
```
- `source` is optional and defaults to `HWW` (backward compatible)
- `key` is optional/ignored if source is `U2F`.




### CREATE or RECOVER U2F
*command*
```
"seed" : 
      "source" : "U2F_create / U2F_load"
      "filename" : "filename"
      "counter" : <number>
```
*reply*
```
"seed" : "success"
```
- For `U2F_create`, `key:password` IS required because a backup with `all` spaces (U2F and HWW) is automatically created. (`key` is used to verify that the HWW backup is correctly saved.)
- `counter` is optional and defaults to no change in counter
- A safe choice of counter for client code is `unix_time_since_u2f_firmware_published * ave_u2f_calls_per_unit_time`. A U2F call once every 10 sec would give over 1000 years before running out of counter space (uint32 counter).



### DEPRECATED/REMOVED
*command*
```
"reset":"u2f"
```
- Removed because the command did not automatically produce a backup (could be confusing to users) and other commands serve its purpose (`seed:U2F_create` to update/reset, and `feature_set:{u2f:false}` to disable)




