### PR TITLE
tests: fix possible segfault in sd.c

### DIFF
--- a/src/sd.c
+++ b/src/sd.c
@@ -88,6 +88,9 @@ uint8_t sd_write(const char *fn, const char *wallet_backup, const char *wallet_n
         }
     }
     FILE *file_object = fopen(file, "w");
+    if (file_object == NULL) {
+        goto err;
+    }
 #else
 
     sd_mmc_init();


### PR DESCRIPTION
When the backup file can't be created in the host file system, the
test segfaults.