### PR TITLE
sign: error on empty data

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -730,7 +730,7 @@ static int commander_process_sign(yajl_val json_node)
     const char *data_path[] = { cmd_str(CMD_sign), cmd_str(CMD_data), NULL };
     yajl_val data = yajl_tree_get(json_node, data_path, yajl_t_array);
 
-    if (!data) {
+    if (!YAJL_IS_ARRAY(data) || data->u.array.len == 0) {
         commander_fill_report(cmd_str(CMD_sign), NULL, DBB_ERR_IO_INVALID_CMD);
         return DBB_ERROR;
     }
@@ -1455,7 +1455,7 @@ static int commander_echo_command(yajl_val json_node)
         commander_fill_report(cmd_str(CMD_meta), meta, DBB_OK);
     }
 
-    if (!YAJL_IS_ARRAY(data)) {
+    if (!YAJL_IS_ARRAY(data) || data->u.array.len == 0) {
         commander_clear_report();
         commander_fill_report(cmd_str(CMD_sign), NULL, DBB_ERR_IO_INVALID_CMD);
         return DBB_ERROR;

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -1997,6 +1997,7 @@ static void tests_sign(void)
 {
     int i, res;
     char *echo;
+
     char one_input_msg[] = "c6fa4c236f59020ec8ffde22f85a78e7f256e94cd975eb5199a4a5cc73e26e4a";
     char one_input[] =
         "{\"meta\":\"_meta_data_\", \"data\":[{\"hash\":\"c6fa4c236f59020ec8ffde22f85a78e7f256e94cd975eb5199a4a5cc73e26e4a\", \"keypath\":\"m/44'/0'/0'/1/7\"}]}";
@@ -2126,6 +2127,13 @@ static void tests_sign(void)
     api_format_send_cmd(cmd_str(CMD_sign), "", KEY_STANDARD);
     ASSERT_REPORT_HAS(flag_msg(DBB_ERR_IO_REPORT_BUF));
 
+    // sig using no inputs
+    api_format_send_cmd(cmd_str(CMD_sign), "{\"meta\":\"_meta_data_\", \"data\":[]}", KEY_STANDARD);
+    ASSERT_REPORT_HAS(flag_msg(DBB_ERR_IO_INVALID_CMD));
+
+    // invalid data field
+    api_format_send_cmd(cmd_str(CMD_sign), "{\"meta\":\"_meta_data_\", \"data\":true}", KEY_STANDARD);
+    ASSERT_REPORT_HAS(flag_msg(DBB_ERR_IO_INVALID_CMD));
 
     // sign using one input
     api_format_send_cmd(cmd_str(CMD_sign), one_input, KEY_STANDARD);


### PR DESCRIPTION
Before, it would return an invalid json `{"sign":}`.

Also, the data checks are now consistent in echo/sign.