### PR TITLE
refactoring for better readability

### DIFF
--- a/src/bootloader.c
+++ b/src/bootloader.c
@@ -116,8 +116,8 @@ static void bootloader_write_chunk(const char *buf, uint8_t chunknum)
         return;
     }
 
-    if (!memcmp((uint32_t *)(FLASH_APP_START + (chunknum * FLASH_BOOT_CHUNK_LEN)), buf,
-                FLASH_BOOT_CHUNK_LEN)) {
+    if (MEMEQ((uint32_t *)(FLASH_APP_START + (chunknum * FLASH_BOOT_CHUNK_LEN)), buf,
+              FLASH_BOOT_CHUNK_LEN)) {
         bootloader_report_status(OP_STATUS_OK);
         bootloader_loading_ready = 1;
         return;
@@ -131,7 +131,7 @@ static void bootloader_write_chunk(const char *buf, uint8_t chunknum)
             return;
         }
 
-        if (memcmp((uint32_t *)(FLASH_APP_START + (chunknum * FLASH_BOOT_CHUNK_LEN) +
+        if (!MEMEQ((uint32_t *)(FLASH_APP_START + (chunknum * FLASH_BOOT_CHUNK_LEN) +
                                 (i * IFLASH0_PAGE_SIZE)), buf + (i * IFLASH0_PAGE_SIZE), IFLASH0_PAGE_SIZE)) {
             bootloader_report_status(OP_STATUS_ERR_CHECK);
             return;

--- a/src/memory.c
+++ b/src/memory.c
@@ -64,7 +64,7 @@ __extension__ static uint8_t MEM_user_entropy[] = {[0 ... MEM_PAGE_LEN - 1] = 0x
 __extension__ static uint8_t MEM_aeskey_stand[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
 __extension__ static uint8_t MEM_aeskey_hidden[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
 __extension__ static uint8_t MEM_aeskey_verify[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
-__extension__ static uint8_t MEM_master_hww_entropy[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
+__extension__ static uint8_t MEM_master_hww_entropy[] = {[0 ... MEM_PAGE_LEN - 1] = 0x00};
 __extension__ static uint8_t MEM_master_hww_chain[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
 __extension__ static uint8_t MEM_master_hww[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
 __extension__ static uint8_t MEM_hidden_hww_chain[] = {[0 ... MEM_PAGE_LEN - 1] = 0xFF};
@@ -91,7 +91,7 @@ static uint8_t memory_eeprom(uint8_t *write_b, uint8_t *read_b, const int32_t ad
 #ifndef TESTING
         // skip writing if memory does not change
         if (read_b) {
-            if (!memcmp(read_b, write_b, len)) {
+            if (MEMEQ(read_b, write_b, len)) {
                 return DBB_OK;
             }
         }
@@ -100,7 +100,7 @@ static uint8_t memory_eeprom(uint8_t *write_b, uint8_t *read_b, const int32_t ad
             return DBB_ERROR;
         }
         if (read_b) {
-            if (!memcmp(write_b, read_b, len)) {
+            if (MEMEQ(write_b, read_b, len)) {
                 return DBB_OK;
             } else {
                 // error
@@ -136,7 +136,7 @@ static uint8_t memory_eeprom_crypt(const uint8_t *write_b, uint8_t *read_b,
     uint8_t rn[FLASH_USERSIG_RN_LEN] = {0};
     sha256_Raw((uint8_t *)(FLASH_BOOT_START), FLASH_BOOT_LEN, mempass);
     flash_read_user_signature((uint32_t *)rn, FLASH_USERSIG_RN_LEN / sizeof(uint32_t));
-    if (memcmp(rn, MEM_PAGE_ERASE, FLASH_USERSIG_RN_LEN)) {
+    if (!MEMEQ(rn, MEM_PAGE_ERASE, FLASH_USERSIG_RN_LEN)) {
         hmac_sha256(mempass, MEM_PAGE_LEN, rn, FLASH_USERSIG_RN_LEN, mempass);
     }
 #endif
@@ -377,7 +377,7 @@ uint8_t *memory_name(const char *name)
 uint8_t *memory_hidden_hww(const uint8_t *master)
 {
     memory_eeprom_crypt(NULL, MEM_hidden_hww, MEM_HIDDEN_BIP32_ADDR);
-    if ((master == NULL) && !memcmp(MEM_hidden_hww, MEM_PAGE_ERASE, 32)) {
+    if ((master == NULL) && MEMEQ(MEM_hidden_hww, MEM_PAGE_ERASE, 32)) {
         // Backward compatible with firmware <=2.2.3
         return memory_master_hww_chaincode(NULL);
     }
@@ -389,7 +389,7 @@ uint8_t *memory_hidden_hww(const uint8_t *master)
 uint8_t *memory_hidden_hww_chaincode(const uint8_t *chain)
 {
     memory_eeprom_crypt(NULL, MEM_hidden_hww_chain, MEM_HIDDEN_BIP32_CHAIN_ADDR);
-    if ((chain == NULL) && !memcmp(MEM_hidden_hww_chain, MEM_PAGE_ERASE, 32)) {
+    if ((chain == NULL) && MEMEQ(MEM_hidden_hww_chain, MEM_PAGE_ERASE, 32)) {
         // Backward compatible with firmware <=2.2.3
         return memory_master_hww(NULL);
     }

--- a/src/u2f_device.c
+++ b/src/u2f_device.c
@@ -313,7 +313,7 @@ static void u2f_device_authenticate(const USB_APDU *a)
     for (i = 0; i < U2F_HIJACK_ORIGIN_TOTAL; i++) {
         // As an alternative interface, hijack the U2F AUTH key handle data field.
         // Slower but works in browsers for specified sites without requiring an extension.
-        if (!memcmp(req->challenge, U2F_HIJACK_CODE[i], U2F_NONCE_LENGTH)) {
+        if (MEMEQ(req->challenge, U2F_HIJACK_CODE[i], U2F_NONCE_LENGTH)) {
             if (!(memory_report_ext_flags() & MEM_EXT_MASK_U2F_HIJACK)) {
                 // Abort U2F hijack commands if the U2F_hijack bit is not set (== disabled).
                 u2f_send_err_hid(cid, U2FHID_ERR_CHANNEL_BUSY);
@@ -333,7 +333,7 @@ static void u2f_device_authenticate(const USB_APDU *a)
 
     u2f_keyhandle_gen(req->appId, nonce, privkey, mac);
 
-    if (memcmp(req->keyHandle, mac, SHA256_DIGEST_LENGTH) != 0) {
+    if (!MEMEQ(req->keyHandle, mac, SHA256_DIGEST_LENGTH)) {
         u2f_send_error(U2F_SW_WRONG_DATA);
         return;
     }

--- a/src/utils.h
+++ b/src/utils.h
@@ -36,10 +36,11 @@
 
 #define UTILS_BUFFER_LEN COMMANDER_REPORT_SIZE
 #define VARINT_LEN 20
-#define MIN(a, b)  (((a) < (b)) ? (a) : (b))
-#define MAX(a, b)  (((a) > (b)) ? (a) : (b))
-#define strlens(s) (s == NULL ? 0 : strlen(s))
-#define STREQ(a, b) (strcmp((a), (b))  == 0)
+#define MIN(a, b)      (((a) < (b)) ? (a) : (b))
+#define MAX(a, b)      (((a) > (b)) ? (a) : (b))
+#define strlens(s)     (s == NULL ? 0 : strlen(s))
+#define STREQ(a, b)    (strcmp((a), (b))  == 0)
+#define MEMEQ(a, b, c) (memcmp((a), (b), (c))  == 0)
 
 
 volatile void *utils_zero(volatile void *dst, size_t len);

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -84,9 +84,9 @@ uint8_t *wallet_get_chaincode(void)
 
 int wallet_seeded(void)
 {
-    if (!memcmp(memory_master_hww(NULL), MEM_PAGE_ERASE, 32)  ||
-            !memcmp(memory_master_hww_chaincode(NULL), MEM_PAGE_ERASE, 32) ||
-            !memcmp(memory_master_hww_entropy(NULL), MEM_PAGE_ERASE, 32)) {
+    if (MEMEQ(memory_master_hww(NULL), MEM_PAGE_ERASE, 32)  ||
+            MEMEQ(memory_master_hww_chaincode(NULL), MEM_PAGE_ERASE, 32) ||
+            MEMEQ(memory_master_hww_entropy(NULL), MEM_PAGE_ERASE, 32)) {
         return DBB_ERROR;
     } else {
         return DBB_OK;
@@ -95,11 +95,11 @@ int wallet_seeded(void)
 
 int wallet_erased(void)
 {
-    if (memcmp(memory_master_hww(NULL), MEM_PAGE_ERASE, 32)  ||
-            memcmp(memory_master_hww_chaincode(NULL), MEM_PAGE_ERASE, 32)  ||
-            memcmp(memory_hidden_hww(NULL), MEM_PAGE_ERASE_FE, 32)  ||
-            memcmp(memory_hidden_hww_chaincode(NULL), MEM_PAGE_ERASE_FE, 32)  ||
-            memcmp(memory_master_hww_entropy(NULL), MEM_PAGE_ERASE, 32)) {
+    if (!MEMEQ(memory_master_hww(NULL), MEM_PAGE_ERASE, 32)  ||
+            !MEMEQ(memory_master_hww_chaincode(NULL), MEM_PAGE_ERASE, 32)  ||
+            !MEMEQ(memory_hidden_hww(NULL), MEM_PAGE_ERASE_FE, 32)  ||
+            !MEMEQ(memory_hidden_hww_chaincode(NULL), MEM_PAGE_ERASE_FE, 32)  ||
+            !MEMEQ(memory_master_hww_entropy(NULL), MEM_PAGE_ERASE, 32)) {
         return DBB_ERROR;
     } else {
         return DBB_OK;

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -83,7 +83,7 @@ static void tests_seed_xpub_backup(void)
     api_reset_device();
 
     api_format_send_cmd(cmd_str(CMD_password), tests_pwd, NULL);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     // rename
     api_format_send_cmd(cmd_str(CMD_name), name0, KEY_STANDARD);
@@ -119,18 +119,18 @@ static void tests_seed_xpub_backup(void)
 
     // backup
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
     ASSERT_REPORT_HAS_NOT(filename_create);
     ASSERT_REPORT_HAS_NOT(flag_msg(DBB_ERR_SD_ERASE));
 
     api_format_send_cmd(cmd_str(CMD_backup), back, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     // erase device
     api_reset_device();
 
     api_format_send_cmd(cmd_str(CMD_password), tests_pwd, NULL);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     // check has default name
     api_format_send_cmd(cmd_str(CMD_name), "", KEY_STANDARD);
@@ -160,10 +160,10 @@ static void tests_seed_xpub_backup(void)
     ASSERT_REPORT_HAS_NOT(filename_create);
 
     api_format_send_cmd(cmd_str(CMD_backup), check, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), KEY_STANDARD);
     ASSERT_REPORT_HAS_NOT(filename);
@@ -176,10 +176,10 @@ static void tests_seed_xpub_backup(void)
     api_reset_device();
 
     api_format_send_cmd(cmd_str(CMD_password), tests_pwd, NULL);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_seed), seed_create, KEY_STANDARD);
     ASSERT_REPORT_HAS_NOT(attr_str(ATTR_error));
@@ -204,7 +204,7 @@ static void tests_seed_xpub_backup(void)
         snprintf(lbn, sizeof(lbn), "%lu%s", (unsigned long)i, long_backup_name);
         snprintf(back, sizeof(back), "{\"filename\":\"%s\", \"key\":\"password\"}", lbn);
         api_format_send_cmd(cmd_str(CMD_backup), back, KEY_STANDARD);
-        ASSERT_SUCCESS
+        ASSERT_SUCCESS;
 
         api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), KEY_STANDARD);
         ASSERT_REPORT_HAS_NOT(cmd_str(CMD_warning));
@@ -213,13 +213,13 @@ static void tests_seed_xpub_backup(void)
     snprintf(lbn, sizeof(lbn), "%lu%s", (unsigned long)i, long_backup_name);
     snprintf(back, sizeof(back), "{\"filename\":\"%s\", \"key\":\"password\"}", lbn);
     api_format_send_cmd(cmd_str(CMD_backup), back, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), KEY_STANDARD);
     ASSERT_REPORT_HAS(cmd_str(CMD_warning));
 
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     // test keypath
     api_format_send_cmd(cmd_str(CMD_xpub), "m/111'", KEY_STANDARD);
@@ -290,11 +290,11 @@ static void tests_seed_xpub_backup(void)
 
     snprintf(back, sizeof(back), "{\"filename\":\"%s\", \"key\":\"password\"}", filename);
     api_format_send_cmd(cmd_str(CMD_backup), back, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(check, sizeof(check), "{\"check\":\"%s\", \"key\":\"password\"}", filename);
     api_format_send_cmd(cmd_str(CMD_backup), check, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_seed), seed_create_2, KEY_STANDARD);
     ASSERT_REPORT_HAS_NOT(attr_str(ATTR_error));
@@ -315,7 +315,7 @@ static void tests_seed_xpub_backup(void)
     if (!TEST_LIVE_DEVICE) {
         // testing buffer gets overwritten by seed command, so reset it
         api_format_send_cmd(cmd_str(CMD_backup), back, KEY_STANDARD);
-        ASSERT_SUCCESS
+        ASSERT_SUCCESS;
     }
 
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), KEY_STANDARD);
@@ -325,7 +325,7 @@ static void tests_seed_xpub_backup(void)
              filename);
 
     api_format_send_cmd(cmd_str(CMD_backup), erase_file, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(erase_file, sizeof(erase_file), "{\"%s\":\"%s\"}", attr_str(ATTR_erase),
              filename_bad);
@@ -343,10 +343,10 @@ static void tests_seed_xpub_backup(void)
     api_reset_device();
 
     api_format_send_cmd(cmd_str(CMD_password), tests_pwd, NULL);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     // seed with extra entropy from device
     api_format_send_cmd(cmd_str(CMD_seed), seed_usb, KEY_STANDARD);
@@ -372,7 +372,7 @@ static void tests_seed_xpub_backup(void)
 
     // load backup
     api_format_send_cmd(cmd_str(CMD_seed), seed_b, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     // verify xpub matches
     api_format_send_cmd(cmd_str(CMD_xpub), "m/0'", KEY_STANDARD);
@@ -383,7 +383,7 @@ static void tests_seed_xpub_backup(void)
 
     // clean up sd card
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 }
 
 
@@ -395,7 +395,7 @@ static void tests_random(void)
     api_reset_device();
 
     api_format_send_cmd(cmd_str(CMD_password), tests_pwd, NULL);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_random), attr_str(ATTR_pseudo), KEY_STANDARD);
     ASSERT_REPORT_HAS_NOT(attr_str(ATTR_error));
@@ -433,7 +433,7 @@ static void tests_name(void)
     api_reset_device();
 
     api_format_send_cmd(cmd_str(CMD_password), tests_pwd, NULL);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_name), name0, KEY_STANDARD);
     ASSERT_REPORT_HAS_NOT(attr_str(ATTR_error));
@@ -466,10 +466,10 @@ static void tests_u2f(void)
     u_assert_int_eq(r.init.bcntl, 0);
 
     api_format_send_cmd(cmd_str(CMD_password), tests_pwd, NULL);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     // Seed
     api_format_send_cmd(cmd_str(CMD_device), attr_str(ATTR_info), KEY_STANDARD);
@@ -490,7 +490,7 @@ static void tests_u2f(void)
 
     // Disable U2F
     api_format_send_cmd(cmd_str(CMD_feature_set), "{\"U2F\":false}", KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_device), attr_str(ATTR_info), KEY_STANDARD);
     if (TEST_U2FAUTH_HIJACK) {
@@ -511,7 +511,7 @@ static void tests_u2f(void)
     // Enable U2F - Must be done through HWW interface.
     TEST_U2FAUTH_HIJACK = 0;
     api_format_send_cmd(cmd_str(CMD_feature_set), "{\"U2F\":true}", KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
     TEST_U2FAUTH_HIJACK = test_u2fauth_hijack;
 
     api_format_send_cmd(cmd_str(CMD_device), attr_str(ATTR_info), KEY_STANDARD);
@@ -521,7 +521,7 @@ static void tests_u2f(void)
 
     // Disable U2F hijack
     api_format_send_cmd(cmd_str(CMD_feature_set), "{\"U2F_hijack\":false}", KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_device), attr_str(ATTR_info), KEY_STANDARD);
     if (TEST_U2FAUTH_HIJACK) {
@@ -541,7 +541,7 @@ static void tests_u2f(void)
     // Enable U2F hijack - Must be done through HWW interface.
     TEST_U2FAUTH_HIJACK = 0;
     api_format_send_cmd(cmd_str(CMD_feature_set), "{\"U2F_hijack\":true}", KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
     TEST_U2FAUTH_HIJACK = test_u2fauth_hijack;
 
     api_format_send_cmd(cmd_str(CMD_device), attr_str(ATTR_info), KEY_STANDARD);
@@ -592,10 +592,10 @@ static void tests_u2f(void)
     api_reset_device();
 
     api_format_send_cmd(cmd_str(CMD_password), tests_pwd, NULL);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd),
              "{\"source\":\"%s\", \"key\":\"password\", \"filename\":\"%s\", \"U2F_counter\":100}",
@@ -617,21 +617,21 @@ static void tests_u2f(void)
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"source\":\"%s\"}", fn0,
              attr_str(ATTR_U2F));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\",\"source\":\"%s\"}",
              fn0, attr_str(ATTR_HWW));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\"}", fn0);
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\",\"source\":\"\"}",
              fn0);
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\",\"source\":\"%s\"}",
              fn0, attr_str(ATTR_all));
@@ -660,7 +660,7 @@ static void tests_u2f(void)
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"source\":\"%s\"}", fn0,
              attr_str(ATTR_U2F));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\",\"source\":\"%s\"}",
              fn0, attr_str(ATTR_HWW));
@@ -674,16 +674,16 @@ static void tests_u2f(void)
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"source\":\"%s\"}", fn1,
              attr_str(ATTR_U2F));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\",\"source\":\"%s\"}",
              fn1, attr_str(ATTR_HWW));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\"}", fn1);
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
 
     // reset u2f (creates backup2 `all` by default)
@@ -717,7 +717,7 @@ static void tests_u2f(void)
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"source\":\"%s\"}", fn2c,
              attr_str(ATTR_U2F));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     // repeat reset u2f without counter field
     snprintf(cmd, sizeof(cmd),
@@ -734,7 +734,7 @@ static void tests_u2f(void)
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"source\":\"%s\"}", fn2,
              attr_str(ATTR_U2F));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
 
     // create backup3 (no source specified -> `all` by default)
@@ -743,22 +743,22 @@ static void tests_u2f(void)
     // create backup3a `all`
     snprintf(cmd, sizeof(cmd), "{\"filename\":\"%s\",\"key\":\"password\"}", fn3);
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"filename\":\"%s\",\"key\":\"password\",\"source\":\"%s\"}",
              fn3h, attr_str(ATTR_HWW));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"filename\":\"%s\",\"source\":\"%s\"}", fn3u,
              attr_str(ATTR_U2F));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"filename\":\"%s\",\"key\":\"password\",\"source\":\"%s\"}",
              fn3a, attr_str(ATTR_all));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
 
 
@@ -792,16 +792,16 @@ static void tests_u2f(void)
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"source\":\"%s\"}", fn2,
              attr_str(ATTR_U2F));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\",\"source\":\"%s\"}",
              fn2, attr_str(ATTR_HWW));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\"}", fn2);
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
 
     // verify backup3 `u2f` success
@@ -810,16 +810,16 @@ static void tests_u2f(void)
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"source\":\"%s\"}", fn3,
              attr_str(ATTR_U2F));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\",\"source\":\"%s\"}",
              fn3, attr_str(ATTR_HWW));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\"}", fn3);
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
 
     // verify backup3h `u2f` fail
@@ -834,7 +834,7 @@ static void tests_u2f(void)
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\",\"source\":\"%s\"}",
              fn3h, attr_str(ATTR_HWW));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\",\"source\":\"%s\"}",
              fn3h, attr_str(ATTR_all));
@@ -843,7 +843,7 @@ static void tests_u2f(void)
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\"}", fn3h);
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
 
     // verify backup3u `u2f` success
@@ -852,7 +852,7 @@ static void tests_u2f(void)
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"source\":\"%s\"}", fn3u,
              attr_str(ATTR_U2F));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\",\"source\":\"%s\"}",
              fn3u, attr_str(ATTR_HWW));
@@ -870,16 +870,16 @@ static void tests_u2f(void)
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"source\":\"%s\"}", fn3a,
              attr_str(ATTR_U2F));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\",\"source\":\"%s\"}",
              fn3a, attr_str(ATTR_HWW));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\"}", fn3a);
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
 
     // recover backup0 u2f
@@ -915,7 +915,7 @@ static void tests_u2f(void)
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"source\":\"%s\"}", fn0,
              attr_str(ATTR_U2F));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\",\"source\":\"%s\"}",
              fn0, attr_str(ATTR_HWW));
@@ -933,12 +933,12 @@ static void tests_u2f(void)
              "{\"source\":\"%s\", \"filename\":\"%s\", \"U2F_counter\":100}", attr_str(ATTR_U2F_load),
              fn3u);
     api_format_send_cmd(cmd_str(CMD_seed), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"source\":\"%s\"}", fn3u,
              attr_str(ATTR_U2F));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
 
     // recover backup0 hww
@@ -948,7 +948,7 @@ static void tests_u2f(void)
              "{\"source\":\"%s\", \"filename\":\"%s\", \"key\":\"password\"}", attr_str(ATTR_backup),
              fn0);
     api_format_send_cmd(cmd_str(CMD_seed), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd),
              "{\"source\":\"%s\", \"filename\":\"%s\", \"key\":\"password\"}", attr_str(ATTR_U2F_load),
@@ -981,7 +981,7 @@ static void tests_u2f(void)
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\",\"source\":\"%s\"}",
              fn0, attr_str(ATTR_HWW));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\",\"source\":\"%s\"}",
              fn0, attr_str(ATTR_all));
@@ -990,7 +990,7 @@ static void tests_u2f(void)
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\"}", fn0);
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
 
     // verify backup3u `u2f` success
@@ -1003,18 +1003,18 @@ static void tests_u2f(void)
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"source\":\"%s\"}", fn3u,
              attr_str(ATTR_U2F));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\",\"source\":\"%s\"}",
              fn0, attr_str(ATTR_HWW));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd),
              "{\"source\":\"%s\", \"key\":\"password\", \"filename\":\"%s\"}",
              attr_str(ATTR_U2F_create), fn4);
     api_format_send_cmd(cmd_str(CMD_seed), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_reset), attr_str(ATTR_U2F), KEY_STANDARD);
     ASSERT_REPORT_HAS(flag_msg(DBB_ERR_IO_INVALID_CMD));
@@ -1027,12 +1027,12 @@ static void tests_u2f(void)
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"source\":\"%s\"}", fn4,
              attr_str(ATTR_U2F));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"password\",\"source\":\"%s\"}",
              fn0, attr_str(ATTR_HWW));
     api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
 
     //
@@ -1076,7 +1076,7 @@ static void tests_u2f(void)
         snprintf(cmd, sizeof(cmd), "{\"source\":\"%s\", \"filename\":\"%s\"}",
                  attr_str(ATTR_U2F_load), tb_v2_3u);
         api_format_send_cmd(cmd_str(CMD_seed), cmd, KEY_STANDARD);
-        ASSERT_SUCCESS
+        ASSERT_SUCCESS;
 
         snprintf(cmd, sizeof(cmd), "{\"source\":\"%s\", \"filename\":\"%s\", \"key\":\"key\"}",
                  attr_str(ATTR_backup), tb_v2_3u);
@@ -1086,7 +1086,7 @@ static void tests_u2f(void)
         snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"source\":\"%s\"}", tb_v2_3u,
                  attr_str(ATTR_U2F));
         api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-        ASSERT_SUCCESS
+        ASSERT_SUCCESS;
 
         snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"key\",\"source\":\"%s\"}",
                  tb_v2_3u, attr_str(ATTR_HWW));
@@ -1112,12 +1112,12 @@ static void tests_u2f(void)
         snprintf(cmd, sizeof(cmd), "{\"source\":\"%s\", \"filename\":\"%s\"}",
                  attr_str(ATTR_U2F_load), fn4);
         api_format_send_cmd(cmd_str(CMD_seed), cmd, KEY_STANDARD);
-        ASSERT_SUCCESS
+        ASSERT_SUCCESS;
 
         snprintf(cmd, sizeof(cmd), "{\"source\":\"%s\", \"filename\":\"%s\", \"key\":\"key\"}",
                  attr_str(ATTR_backup), tb_v2_3h);
         api_format_send_cmd(cmd_str(CMD_seed), cmd, KEY_STANDARD);
-        ASSERT_SUCCESS
+        ASSERT_SUCCESS;
 
         snprintf(cmd, sizeof(cmd), "{\"source\":\"%s\", \"filename\":\"%s\"}",
                  attr_str(ATTR_U2F_load), tb_v2_3h);
@@ -1127,12 +1127,12 @@ static void tests_u2f(void)
         snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"source\":\"%s\"}", fn4,
                  attr_str(ATTR_U2F));
         api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-        ASSERT_SUCCESS
+        ASSERT_SUCCESS;
 
         snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"key\",\"source\":\"%s\"}",
                  tb_v2_3h, attr_str(ATTR_HWW));
         api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-        ASSERT_SUCCESS
+        ASSERT_SUCCESS;
 
         api_format_send_cmd(cmd_str(CMD_sign), one_input, KEY_STANDARD);
         ASSERT_REPORT_HAS(cmd_str(CMD_echo));
@@ -1150,12 +1150,12 @@ static void tests_u2f(void)
         snprintf(cmd, sizeof(cmd), "{\"source\":\"%s\", \"filename\":\"%s\", \"key\":\"key\"}",
                  attr_str(ATTR_backup), fn4);
         api_format_send_cmd(cmd_str(CMD_seed), cmd, KEY_STANDARD);
-        ASSERT_SUCCESS
+        ASSERT_SUCCESS;
 
         snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"key\",\"source\":\"%s\"}", fn4,
                  attr_str(ATTR_HWW));
         api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-        ASSERT_SUCCESS
+        ASSERT_SUCCESS;
 
         api_format_send_cmd(cmd_str(CMD_sign), one_input, KEY_STANDARD);
         ASSERT_REPORT_HAS(cmd_str(CMD_echo));
@@ -1177,32 +1177,32 @@ static void tests_u2f(void)
         snprintf(cmd, sizeof(cmd), "{\"source\":\"%s\", \"filename\":\"%s\"}",
                  attr_str(ATTR_U2F_load), tb_v2_3a);
         api_format_send_cmd(cmd_str(CMD_seed), cmd, KEY_STANDARD);
-        ASSERT_SUCCESS
+        ASSERT_SUCCESS;
 
         snprintf(cmd, sizeof(cmd), "{\"source\":\"%s\", \"filename\":\"%s\", \"key\":\"key\"}",
                  attr_str(ATTR_backup), tb_v2_3a);
         api_format_send_cmd(cmd_str(CMD_seed), cmd, KEY_STANDARD);
-        ASSERT_SUCCESS
+        ASSERT_SUCCESS;
 
         snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"source\":\"%s\"}", tb_v2_3a,
                  attr_str(ATTR_U2F));
         api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-        ASSERT_SUCCESS
+        ASSERT_SUCCESS;
 
         snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"source\":\"%s\"}", tb_v2_3u,
                  attr_str(ATTR_U2F));
         api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-        ASSERT_SUCCESS
+        ASSERT_SUCCESS;
 
         snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"key\",\"source\":\"%s\"}",
                  tb_v2_3a, attr_str(ATTR_HWW));
         api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-        ASSERT_SUCCESS
+        ASSERT_SUCCESS;
 
         snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"key\",\"source\":\"%s\"}",
                  tb_v2_3h, attr_str(ATTR_HWW));
         api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-        ASSERT_SUCCESS
+        ASSERT_SUCCESS;
 
         api_format_send_cmd(cmd_str(CMD_sign), one_input, KEY_STANDARD);
         ASSERT_REPORT_HAS(cmd_str(CMD_echo));
@@ -1220,12 +1220,12 @@ static void tests_u2f(void)
         snprintf(cmd, sizeof(cmd), "{\"source\":\"%s\", \"filename\":\"%s\", \"key\":\"key\"}",
                  attr_str(ATTR_backup), fn4);
         api_format_send_cmd(cmd_str(CMD_seed), cmd, KEY_STANDARD);
-        ASSERT_SUCCESS
+        ASSERT_SUCCESS;
 
         snprintf(cmd, sizeof(cmd), "{\"check\":\"%s\",\"key\":\"key\",\"source\":\"%s\"}", fn4,
                  attr_str(ATTR_HWW));
         api_format_send_cmd(cmd_str(CMD_backup), cmd, KEY_STANDARD);
-        ASSERT_SUCCESS
+        ASSERT_SUCCESS;
 
         api_format_send_cmd(cmd_str(CMD_sign), one_input, KEY_STANDARD);
         ASSERT_REPORT_HAS(cmd_str(CMD_echo));
@@ -1243,7 +1243,7 @@ static void tests_u2f(void)
         snprintf(cmd, sizeof(cmd), "{\"source\":\"%s\", \"filename\":\"%s\", \"key\":\"key\"}",
                  attr_str(ATTR_backup), tb_v2_2);
         api_format_send_cmd(cmd_str(CMD_seed), cmd, KEY_STANDARD);
-        ASSERT_SUCCESS
+        ASSERT_SUCCESS;
 
         snprintf(cmd, sizeof(cmd), "{\"source\":\"%s\", \"filename\":\"%s\"}",
                  attr_str(ATTR_U2F_load), tb_v2_2);
@@ -1264,7 +1264,7 @@ static void tests_u2f(void)
 
     // clean up sd card
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 }
 
 
@@ -1276,16 +1276,16 @@ static void tests_device(void)
     ASSERT_REPORT_HAS(attr_str(ATTR_false));
 
     api_format_send_cmd(cmd_str(CMD_password), tests_pwd, NULL);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_ping), "", NULL);
     ASSERT_REPORT_HAS(attr_str(ATTR_password));
 
     api_format_send_cmd(cmd_str(CMD_led), attr_str(ATTR_blink), KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_led), attr_str(ATTR_abort), KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_led), "invalid_cmd", KEY_STANDARD);
     ASSERT_REPORT_HAS(flag_msg(DBB_ERR_IO_INVALID_CMD));
@@ -1344,18 +1344,18 @@ static void tests_device(void)
     ASSERT_REPORT_HAS(flag_msg(DBB_ERR_IO_INVALID_CMD));
 
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_seed),
                         "{\"source\":\"create\", \"filename\":\"c.pdf\", \"key\":\"password\"}", KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_verifypass), attr_str(ATTR_create), KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_backup), "{\"filename\":\"b.pdf\", \"key\":\"password\"}",
                         KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_device), attr_str(ATTR_lock), KEY_STANDARD);
     ASSERT_REPORT_HAS_NOT(attr_str(ATTR_error));
@@ -1408,7 +1408,7 @@ static void tests_device(void)
     api_reset_device();
 
     api_format_send_cmd(cmd_str(CMD_password), tests_pwd, NULL);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_device), attr_str(ATTR_info), KEY_STANDARD);
     ASSERT_REPORT_HAS_NOT(attr_str(ATTR_error));
@@ -1446,7 +1446,7 @@ static void tests_device(void)
     }
 
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     if (!TEST_LIVE_DEVICE) {
         commander_force_reset();
@@ -1467,13 +1467,13 @@ static void tests_input(void)
     }
 
     api_format_send_cmd(cmd_str(CMD_password), tests_pwd, NULL);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_send_cmd("{\"name\": \"name\"}", KEY_STANDARD);
     ASSERT_REPORT_HAS_NOT(attr_str(ATTR_error));
 
     api_format_send_cmd(cmd_str(CMD_password), tests_pwd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_send_cmd("{\"name\": \"name\"}", KEY_STANDARD);
     ASSERT_REPORT_HAS_NOT(attr_str(ATTR_error));
@@ -1565,7 +1565,7 @@ static void tests_password(void)
     ASSERT_REPORT_HAS(flag_msg(DBB_ERR_IO_PASSWORD_LEN));
 
     api_format_send_cmd(cmd_str(CMD_password), tests_pwd, NULL);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_password), tests_pwd, NULL);
     ASSERT_REPORT_HAS(flag_msg(DBB_ERR_IO_JSON_PARSE));
@@ -1615,12 +1615,12 @@ static void tests_password(void)
     ASSERT_REPORT_HAS(flag_msg(DBB_ERR_KEY_MASTER));
     // Erase backups
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
     // Seed wallets
     snprintf(cmd, sizeof(cmd),
              "{\"source\":\"create\",\"filename\":\"h.pdf\",\"key\":\"%s\"}", tests_pwd);
     api_format_send_cmd(cmd_str(CMD_seed), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
     // Send deprecated command to set hidden key
     api_format_send_cmd(cmd_str(CMD_hidden_password), "1234", KEY_STANDARD);
     ASSERT_REPORT_HAS(flag_msg(DBB_ERR_IO_INVALID_CMD));
@@ -1644,7 +1644,7 @@ static void tests_password(void)
     snprintf(cmd, sizeof(cmd), "{\"%s\":\"%s\",\"%s\":\"%s\"}", cmd_str(CMD_password),
              hidden_pwd, cmd_str(CMD_key), hidden_pwd);
     api_format_send_cmd(cmd_str(CMD_hidden_password), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
     // Login to hidden wallet
     api_format_send_cmd(cmd_str(CMD_name), "", KEY_HIDDEN);
     ASSERT_REPORT_HAS_NOT(attr_str(ATTR_error));
@@ -1663,7 +1663,7 @@ static void tests_password(void)
     // Reset standard password
     api_format_send_cmd(cmd_str(CMD_password), tests_pwd, KEY_HIDDEN);
     if (!TEST_U2FAUTH_HIJACK) {
-        ASSERT_SUCCESS
+        ASSERT_SUCCESS;
     }
     // Login to standard wallet (hidden key)
     api_format_send_cmd(cmd_str(CMD_name), "", KEY_STANDARD);
@@ -1677,7 +1677,7 @@ static void tests_password(void)
     snprintf(cmd, sizeof(cmd), "{\"%s\":\"%s\",\"%s\":\"%s\"}", cmd_str(CMD_password),
              hidden_pwd, cmd_str(CMD_key), hidden_pwd);
     api_format_send_cmd(cmd_str(CMD_hidden_password), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
     // Login to hidden wallet
     api_format_send_cmd(cmd_str(CMD_name), "", KEY_HIDDEN);
     ASSERT_REPORT_HAS_NOT(attr_str(ATTR_error));
@@ -1701,7 +1701,7 @@ static void tests_password(void)
     snprintf(cmd, sizeof(cmd), "{\"%s\":\"%s\",\"%s\":\"%s\"}", cmd_str(CMD_password),
              hidden_pwd, cmd_str(CMD_key), hidden_pwd);
     api_format_send_cmd(cmd_str(CMD_hidden_password), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
     // Login to hidden wallet
     api_format_send_cmd(cmd_str(CMD_name), "", KEY_HIDDEN);
     ASSERT_REPORT_HAS_NOT(attr_str(ATTR_error));
@@ -1728,7 +1728,7 @@ static void tests_password(void)
     snprintf(cmd, sizeof(cmd), "{\"%s\":\"%s\",\"%s\":\"%s\"}", cmd_str(CMD_password),
              hidden_pwd, cmd_str(CMD_key), hidden_pwd);
     api_format_send_cmd(cmd_str(CMD_hidden_password), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
     // Get standard wallet xpub
     api_format_send_cmd(cmd_str(CMD_xpub), keypath, KEY_STANDARD);
     ASSERT_REPORT_HAS_NOT(attr_str(ATTR_error));
@@ -1747,7 +1747,7 @@ static void tests_password(void)
     sha256_Raw((const uint8_t *)tmp_pw, strlens(tmp_pw), tmp_key);
     sha256_Raw(tmp_key, MEM_PAGE_LEN, tmp_key);
     api_format_send_cmd(cmd_str(CMD_password), tmp_pw, KEY_HIDDEN);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
     // Login to hidden wallet
     api_format_send_cmd(cmd_str(CMD_name), "", tmp_key);
     ASSERT_REPORT_HAS_NOT(attr_str(ATTR_error));
@@ -1759,7 +1759,7 @@ static void tests_password(void)
     u_assert_str_eq(xpub_hdn, xpub_tst);
     // Change key in hidden wallet back to original
     api_format_send_cmd(cmd_str(CMD_password), hidden_pwd, tmp_key);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
     // Change hidden key in hidden wallet -> error disabled
     snprintf(cmd, sizeof(cmd), "{\"%s\":\"%s\",\"%s\":\"%s\"}", cmd_str(CMD_password),
              "junk_pwd", cmd_str(CMD_key), "junk_pwd");
@@ -1780,7 +1780,7 @@ static void tests_password(void)
     snprintf(cmd, sizeof(cmd),
              "{\"source\":\"backup\",\"filename\":\"h.pdf\",\"key\":\"%s\"}", hidden_pwd);
     api_format_send_cmd(cmd_str(CMD_seed), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
     // Get standard wallet xpub
     // xpubs equal
     api_format_send_cmd(cmd_str(CMD_xpub), keypath, KEY_STANDARD);
@@ -1796,7 +1796,7 @@ static void tests_password(void)
     snprintf(cmd, sizeof(cmd),
              "{\"source\":\"backup\",\"filename\":\"h.pdf\",\"key\":\"%s\"}", tests_pwd);
     api_format_send_cmd(cmd_str(CMD_seed), cmd, KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
     // Get standard wallet xpub
     // xpubs equal
     api_format_send_cmd(cmd_str(CMD_xpub), keypath, KEY_STANDARD);
@@ -1820,7 +1820,7 @@ static void tests_echo_tfa(void)
     api_reset_device();
 
     api_format_send_cmd(cmd_str(CMD_password), tests_pwd, NULL);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_sign), hash_sign2, KEY_STANDARD);
     u_assert_int_eq((strstr(api_read_decrypted_report(), cmd_str(CMD_echo)) ||
@@ -1838,16 +1838,16 @@ static void tests_echo_tfa(void)
 
     // test verifypass
     api_format_send_cmd(cmd_str(CMD_verifypass), attr_str(ATTR_create), KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), KEY_STANDARD);
     ASSERT_REPORT_HAS_NOT(VERIFYPASS_FILENAME);
 
     api_format_send_cmd(cmd_str(CMD_verifypass), attr_str(ATTR_export), KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_list), KEY_STANDARD);
     ASSERT_REPORT_HAS(VERIFYPASS_FILENAME);
@@ -1970,7 +1970,7 @@ static int recover_public_key_verify_sig(const char *sig, const char *hash,
         return 1;
     }
 
-    if (memcmp(utils_hex_to_uint8(pubkey), pubkey_33, public_key_len)) {
+    if (!MEMEQ(utils_hex_to_uint8(pubkey), pubkey_33, public_key_len)) {
         return 1;
     }
 
@@ -2075,11 +2075,11 @@ static void tests_sign(void)
     api_reset_device();
 
     api_format_send_cmd(cmd_str(CMD_password), tests_pwd, NULL);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     // backup
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     // seed
     char seed[] =
@@ -2089,7 +2089,7 @@ static void tests_sign(void)
 
     // clean up sd card
     api_format_send_cmd(cmd_str(CMD_backup), attr_str(ATTR_erase), KEY_STANDARD);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
 
     // missing parameters
@@ -2128,11 +2128,13 @@ static void tests_sign(void)
     ASSERT_REPORT_HAS(flag_msg(DBB_ERR_IO_REPORT_BUF));
 
     // sig using no inputs
-    api_format_send_cmd(cmd_str(CMD_sign), "{\"meta\":\"_meta_data_\", \"data\":[]}", KEY_STANDARD);
+    api_format_send_cmd(cmd_str(CMD_sign), "{\"meta\":\"_meta_data_\", \"data\":[]}",
+                        KEY_STANDARD);
     ASSERT_REPORT_HAS(flag_msg(DBB_ERR_IO_INVALID_CMD));
 
     // invalid data field
-    api_format_send_cmd(cmd_str(CMD_sign), "{\"meta\":\"_meta_data_\", \"data\":true}", KEY_STANDARD);
+    api_format_send_cmd(cmd_str(CMD_sign), "{\"meta\":\"_meta_data_\", \"data\":true}",
+                        KEY_STANDARD);
     ASSERT_REPORT_HAS(flag_msg(DBB_ERR_IO_INVALID_CMD));
 
     // sign using one input
@@ -2333,7 +2335,7 @@ static void tests_memory_setup(void)
     memory_setup(); // run twice
 
     api_format_send_cmd(cmd_str(CMD_password), tests_pwd, NULL);
-    ASSERT_SUCCESS
+    ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_led), "abort", key_00);
     ASSERT_REPORT_HAS(flag_msg(DBB_ERR_IO_JSON_PARSE));


### PR DESCRIPTION
append `;` to `ASSERT_SUCCESS`
use `MEMEQ` instead of `memcmp()==0`