### PR TITLE
Update pairing mechanism and add MAC

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,6 +9,8 @@
 
 set(DBB-FIRMWARE-SOURCES
         aes.c
+        sharedsecret.c
+        aescbcb64.c
         base58.c
         base64.c
         pbkdf2.c
@@ -31,6 +33,7 @@ set(DBB-FIRMWARE-SOURCES
         ataes132.c
         flash.c
         touch.c
+        ecdh.c
 )
 
 if(USE_SECP256K1_LIB)

--- a/src/aescbcb64.c
+++ b/src/aescbcb64.c
@@ -1,0 +1,192 @@
+/*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2015-2018 Douglas J. Bakkum
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "aescbcb64.h"
+#include "hmac.h"
+#include "commander.h"
+#include "sharedsecret.h"
+#include "memory.h"
+#include "base64.h"
+#include "aes.h"
+#include "sha2.h"
+#include "random.h"
+#include "flags.h"
+#include "utils.h"
+
+// Must free() returned value
+static uint8_t *aescbcb64_init_and_encrypt(const unsigned char *in, int inlen,
+        int *out_len,
+        const uint8_t *key)
+{
+    int  pads;
+    int  inpadlen = inlen + N_BLOCK - inlen % N_BLOCK;
+    unsigned char inpad[inpadlen];
+    unsigned char enc[inpadlen];
+    unsigned char iv[N_BLOCK];
+    uint8_t *enc_cat = malloc(sizeof(uint8_t) * (inpadlen +
+                              N_BLOCK)); // concatenating [ iv0  |  enc ]
+    *out_len = inpadlen + N_BLOCK;
+
+    aes_context ctx[1];
+
+    // Set cipher key
+    memset(ctx, 0, sizeof(ctx));
+    aes_set_key(key, 32, ctx);
+
+    // PKCS7 padding
+    memcpy(inpad, in, inlen);
+    for (pads = 0; pads < N_BLOCK - inlen % N_BLOCK; pads++ ) {
+        inpad[inlen + pads] = (N_BLOCK - inlen % N_BLOCK);
+    }
+
+    // Make a random initialization vector
+    if (random_bytes((uint8_t *)iv, N_BLOCK, 0) == DBB_ERROR) {
+        commander_fill_report(cmd_str(CMD_random), NULL, DBB_ERR_MEM_ATAES);
+        utils_zero(inpad, inpadlen);
+        utils_zero(ctx, sizeof(ctx));
+        return NULL;
+    }
+    memcpy(enc_cat, iv, N_BLOCK);
+
+    // CBC encrypt multiple blocks
+    aes_cbc_encrypt(inpad, enc, inpadlen / N_BLOCK, iv, ctx);
+    memcpy(enc_cat + N_BLOCK, enc, inpadlen);
+
+    utils_zero(inpad, inpadlen);
+    utils_zero(ctx, sizeof(ctx));
+    return enc_cat;
+}
+
+
+// Must free() returned value (allocated inside base64() function)
+char *aescbcb64_encrypt(const unsigned char *in, int inlen, int *out_b64len,
+                        const uint8_t *key)
+{
+    int out_len;
+    uint8_t *enc_cat = aescbcb64_init_and_encrypt(in, inlen, &out_len, key);
+    // base64 encoding
+    char *b64;
+    b64 = base64(enc_cat, out_len, out_b64len);
+    free(enc_cat);
+    return b64;
+}
+
+// Encrypts a given constant char array of length inlen using the AES algorithm with CBC mode,
+// appends its SHA256 HMAC and base64 encodes the result.
+//
+// Must free() returned value
+char *aescbcb64_hmac_encrypt(const unsigned char *in, int inlen, int *out_b64len,
+                             const uint8_t *shared_secret)
+{
+    uint8_t encryption_key[SHA256_DIGEST_LENGTH];
+    uint8_t authentication_key[SHA256_DIGEST_LENGTH];
+
+    sharedsecret_derive_keys(shared_secret, encryption_key, authentication_key);
+
+    int encrypt_len;
+    uint8_t *encrypted = aescbcb64_init_and_encrypt(in,
+                         inlen,
+                         &encrypt_len,
+                         encryption_key);
+    uint8_t hmac[SHA256_DIGEST_LENGTH];
+    hmac_sha256(authentication_key, SHA256_DIGEST_LENGTH, encrypted, encrypt_len, hmac);
+
+    uint8_t authenticated_encrypted_msg[encrypt_len + SHA256_DIGEST_LENGTH];
+    memcpy(authenticated_encrypted_msg, encrypted, encrypt_len);
+    memcpy(authenticated_encrypted_msg + encrypt_len, hmac, SHA256_DIGEST_LENGTH);
+
+    free(encrypted);
+    utils_zero(encryption_key, sizeof(encryption_key));
+    utils_zero(authentication_key, sizeof(authentication_key));
+    char *b64 = base64(authenticated_encrypted_msg, encrypt_len + SHA256_DIGEST_LENGTH,
+                       out_b64len);
+    return b64;
+}
+
+char *aescbcb64_init_and_decrypt(uint8_t *ub64, int ub64len, int *decrypt_len,
+                                 const uint8_t *key)
+{
+    *decrypt_len = 0;
+
+    // Set cipher key
+    aes_context ctx[1];
+    memset(ctx, 0, sizeof(ctx));
+    aes_set_key(key, 32, ctx);
+
+    unsigned char dec_pad[ub64len - N_BLOCK];
+    aes_cbc_decrypt(ub64 + N_BLOCK, dec_pad, ub64len / N_BLOCK - 1, ub64, ctx);
+
+    // Strip PKCS7 padding
+    int padlen = dec_pad[ub64len - N_BLOCK - 1];
+    if (ub64len - N_BLOCK - padlen <= 0) {
+        utils_zero(dec_pad, sizeof(dec_pad));
+        utils_zero(ctx, sizeof(ctx));
+        return NULL;
+    }
+    char *dec = malloc(ub64len - N_BLOCK - padlen + 1); // +1 for null termination
+    if (!dec) {
+        utils_zero(dec_pad, sizeof(dec_pad));
+        utils_zero(ctx, sizeof(ctx));
+        return NULL;
+    }
+    memcpy(dec, dec_pad, ub64len - N_BLOCK - padlen);
+    dec[ub64len - N_BLOCK - padlen] = '\0';
+    *decrypt_len = ub64len - N_BLOCK - padlen + 1;
+    utils_zero(dec_pad, sizeof(dec_pad));
+    utils_zero(ctx, sizeof(ctx));
+    return dec;
+}
+
+// Must free() returned value
+char *aescbcb64_decrypt(const unsigned char *in, int inlen, int *decrypt_len,
+                        const uint8_t *key)
+{
+    if (!in || inlen == 0) {
+        return NULL;
+    }
+
+    // Unbase64
+    int ub64len;
+    unsigned char *ub64 = unbase64((const char *)in, inlen, &ub64len);
+    if (!ub64) {
+        return NULL;
+    }
+    if ((ub64len % N_BLOCK) || ub64len < N_BLOCK) {
+        free(ub64);
+        return NULL;
+    }
+
+    char *ret = aescbcb64_init_and_decrypt(ub64, ub64len, decrypt_len, key);
+    memset(ub64, 0, ub64len);
+    free(ub64);
+    return ret;
+}
+
+

--- a/src/aescbcb64.h
+++ b/src/aescbcb64.h
@@ -2,7 +2,7 @@
 
  The MIT License (MIT)
 
- Copyright (c) 2015-2016 Douglas J. Bakkum
+ Copyright (c) 2015-2018 Douglas J. Bakkum
 
  Permission is hereby granted, free of charge, to any person obtaining
  a copy of this software and associated documentation files (the "Software"),
@@ -24,24 +24,20 @@
 
 */
 
-
-#ifndef _LED_H_
-#define _LED_H_
-
-
-#include <stdint.h>
+#ifndef _AESCBCB64_H_
+#define _AESCBCB64_H_
 
 
-#define LED_MAX_CODE_BLINKS 4
-#define LED_MAX_BLINK_SETS  6
+char *aescbcb64_hmac_encrypt(const unsigned char *in, int inlen,
+                             int *out_b64len, const uint8_t *shared_secret);
 
+char *aescbcb64_init_and_decrypt(uint8_t *ub64, int ub64len, int *decrypt_len,
+                                 const uint8_t *key);
 
-void led_on(void);
-void led_off(void);
-void led_toggle(void);
-void led_blink(void);
-void led_abort(void);
-void led_code(uint8_t code);
+char *aescbcb64_encrypt(const unsigned char *in, int inlen,
+                        int *out_b64len, const uint8_t *key);
 
+char *aescbcb64_decrypt(const unsigned char *in, int inlen,
+                        int *decrypt_len, const uint8_t *key);
 
 #endif

--- a/src/commander.h
+++ b/src/commander.h
@@ -33,11 +33,6 @@
 #include "memory.h"
 
 
-char *aes_cbc_b64_encrypt(const unsigned char *in, int inlen, int *out_b64len,
-                          const uint8_t *key);
-char *aes_cbc_b64_decrypt(const unsigned char *in, int inlen, int *decrypt_len,
-                          const uint8_t *key);
-
 void commander_clear_report(void);
 const char *commander_read_report(void);
 const char *commander_read_array(void);

--- a/src/ecdh.c
+++ b/src/ecdh.c
@@ -1,0 +1,289 @@
+/*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2015-2018 Douglas J. Bakkum, Stephanie Stroka, Shift Cryptosecurity
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "ecdh.h"
+#include "random.h"
+#include "sd.h"
+#include "touch.h"
+#include "utils.h"
+#include "commander.h"
+#include "ecc.h"
+#include "led.h"
+#include "memory.h"
+#include "flags.h"
+#include "sha2.h"
+#include "yajl/src/api/yajl_tree.h"
+
+#define SIZE_BYTE 8
+
+#define SIZE_EC_POINT_COMPRESSED 33
+#define SIZE_EC_POINT_COMPRESSED_HEX 66
+#define SIZE_EC_PRIVATE_KEY 32
+
+#define SIZE_SHA256_HEX 64
+
+/**
+ * Holds the private and public elliptic-curve keypair generated for the DH-key exchange.
+ */
+typedef struct TFA_EC_Keypair {
+    uint8_t private_key[SIZE_EC_PRIVATE_KEY];
+    uint8_t public_key[SIZE_EC_POINT_COMPRESSED];
+} TFA_EC_Keypair;
+
+// Stores the SHA-256 hash of the ecdh public key from the mobile app.
+__extension__ static uint8_t TFA_IN_HASH_PUB[] = {[0 ... SHA256_DIGEST_LENGTH - 1] = 0x00};
+__extension__ static uint8_t TFA_ZEROS[] = {[0 ... SHA256_DIGEST_LENGTH - 1] = 0x00};
+
+// Stores the ecdh keypair used in creating the shared secret for the mobile
+// app communication.
+__extension__ static TFA_EC_Keypair tfa_keypair = {
+    {[0 ... SIZE_EC_PRIVATE_KEY - 1] = 0x00},
+    {[0 ... SIZE_EC_POINT_COMPRESSED - 1] = 0x00}
+};
+
+// The position of the yet-to-be-verified byte.
+static uint8_t TFA_VERIFY_BYTEPOS = 0;
+
+// The position of the current 2 bit inside the yet-to-be-verified byte.
+// Valid values are 1 to 4.
+static uint8_t TFA_VERIFY_BITPOS = 1;
+
+/**
+ * Generates a new EC key pair on the SECP256k1 curve and stores it in the address given as a
+ * parameter.
+ */
+static int ecdh_generate_key(TFA_EC_Keypair *keypair)
+{
+    do {
+        if (random_bytes(keypair->private_key, sizeof(keypair->private_key), 0) == DBB_ERROR) {
+            return DBB_ERR_MEM_ATAES;
+        }
+    } while (!bitcoin_ecc.ecc_isValid(keypair->private_key, ECC_SECP256k1));
+
+    ecc_get_public_key33(keypair->private_key, keypair->public_key, ECC_SECP256k1);
+    return DBB_OK;
+}
+
+/**
+ * Processes the { "ecdh" : { "hash_pubkey" : "..." } } command.
+ * The command triggers the (re-)generation of a new ECDH keypair,
+ * which requires a long-touch.
+ * If an error happens, the function prepares a response.
+ */
+static void ecdh_hash_pubkey_command(const char *pair_hash_pubkey)
+{
+    if (strlens(pair_hash_pubkey) != SIZE_SHA256_HEX) {
+        commander_fill_report(cmd_str(CMD_ecdh), NULL, DBB_ERR_KEY_HASH_ECDH_LEN);
+        return;
+    }
+
+    int status = touch_button_press(DBB_TOUCH_LONG);
+    if (status != DBB_TOUCHED) {
+        utils_zero(TFA_IN_HASH_PUB, SHA256_DIGEST_LENGTH);
+        commander_fill_report(cmd_str(CMD_ecdh), NULL, status);
+        return;
+    }
+
+    TFA_VERIFY_BITPOS = 1;
+    TFA_VERIFY_BYTEPOS = 0;
+    int ret = ecdh_generate_key(&tfa_keypair);
+    if (ret != DBB_OK) {
+        utils_zero(TFA_IN_HASH_PUB, SHA256_DIGEST_LENGTH);
+        commander_fill_report(cmd_str(CMD_ecdh), NULL, ret);
+        return;
+    }
+
+    char msg[256];
+    uint8_t hash_pubkey[SHA256_DIGEST_LENGTH];
+    sha256_Raw(tfa_keypair.public_key, sizeof(tfa_keypair.public_key), hash_pubkey);
+    snprintf(msg, sizeof(msg), "{\"%s\":\"%s\"}",
+             cmd_str(CMD_hash_pubkey), utils_uint8_to_hex(hash_pubkey, sizeof(hash_pubkey)));
+
+    memcpy(TFA_IN_HASH_PUB, utils_hex_to_uint8(pair_hash_pubkey), SHA256_DIGEST_LENGTH);
+    commander_clear_report();
+    commander_fill_report(cmd_str(CMD_ecdh), msg, DBB_JSON_ARRAY);
+}
+
+/**
+ * Process the { "ecdh" : { "pubkey" : "..." } } command.
+ * First, we check whether the provided public key is the one to which the pairing partner
+ * committed to in a previous request (hash_pubkey).
+ * Then, we create the ECDH shared secret and store it in the eeprom.
+ * Lastly, the hash of the pairing partner's public key and keypair for generating the shared
+ * secret is reset.
+ */
+static void ecdh_pubkey_command(const char *pair_pubkey)
+{
+    // 66 bytes because it's the hex representation of a compressed EC public key.
+    if (strlens(pair_pubkey) != SIZE_EC_POINT_COMPRESSED_HEX) {
+        commander_fill_report(cmd_str(CMD_ecdh), NULL, DBB_ERR_KEY_ECDH_LEN);
+        goto cleanup;
+    }
+
+    uint8_t pair_pubkey_bytes[SIZE_EC_POINT_COMPRESSED];
+    memcpy(pair_pubkey_bytes, utils_hex_to_uint8(pair_pubkey), SIZE_EC_POINT_COMPRESSED);
+
+    // Point-at-infinity not allowed
+    if (MEMEQ(TFA_ZEROS, pair_pubkey_bytes + 1, SHA256_DIGEST_LENGTH)) {
+        commander_fill_report(cmd_str(CMD_ecdh), NULL, DBB_ERR_TFA_HASH_MATCH);
+        goto cleanup;
+    }
+
+    // Check if hashed pubkey was provided
+    if (MEMEQ(TFA_ZEROS, TFA_IN_HASH_PUB, SHA256_DIGEST_LENGTH)) {
+        commander_fill_report(cmd_str(CMD_ecdh), NULL, DBB_ERR_TFA_HASH_MATCH);
+        goto cleanup;
+    }
+
+    uint8_t h[SHA256_DIGEST_LENGTH];
+    sha256_Raw(pair_pubkey_bytes, SIZE_EC_POINT_COMPRESSED, h);
+
+    // Check if the pubkey matches the provided hashed pubkey
+    if (!MEMEQ(h, TFA_IN_HASH_PUB, SHA256_DIGEST_LENGTH)) {
+        commander_fill_report(cmd_str(CMD_ecdh), NULL, DBB_ERR_TFA_HASH_MATCH);
+        goto cleanup;
+    }
+
+    uint8_t ecdh_shared_secret[SIZE_ECDH_SHARED_SECRET];
+    if (bitcoin_ecc.ecc_ecdh(pair_pubkey_bytes, tfa_keypair.private_key, ecdh_shared_secret,
+                             ECC_SECP256k1)) {
+        commander_fill_report(cmd_str(CMD_ecdh), NULL, DBB_ERR_KEY_ECDH);
+        goto cleanup;
+    }
+
+    uint8_t ret = memory_write_tfa_shared_secret(ecdh_shared_secret);
+    if (ret != DBB_OK) {
+        commander_fill_report(cmd_str(CMD_ecdh), NULL, ret);
+        goto cleanup;
+    }
+
+    char msg[256];
+    snprintf(msg, sizeof(msg), "{\"%s\":\"%s\"}",
+             cmd_str(CMD_pubkey), utils_uint8_to_hex(tfa_keypair.public_key,
+                     sizeof(tfa_keypair.public_key)));
+
+    commander_fill_report(cmd_str(CMD_ecdh), msg, DBB_JSON_OBJECT);
+
+cleanup:
+    utils_zero(TFA_IN_HASH_PUB, SHA256_DIGEST_LENGTH);
+    utils_zero(&tfa_keypair, sizeof(TFA_EC_Keypair));
+    utils_clear_buffers();
+
+}
+
+/**
+ * Challenge the pairing by blinking the LED to verify the shared secret.
+ * When this command is called, the LED blinks 1 - 4 times to communicate the value of the
+ * 2 bits at the current position of the shared secret.
+ * The position is advanced afterwards.
+ */
+static void ecdh_challenge_command(void)
+{
+    uint8_t *shared_secret = memory_report_aeskey(TFA_SHARED_SECRET);
+    uint8_t encryption_and_authentication_key[SHA512_DIGEST_LENGTH];
+    uint8_t encryption_and_authentication_challenge[SHA256_DIGEST_LENGTH];
+
+    sha512_Raw(shared_secret, SIZE_ECDH_SHARED_SECRET, encryption_and_authentication_key);
+    sha256_Raw(encryption_and_authentication_key, SHA512_DIGEST_LENGTH,
+               encryption_and_authentication_challenge);
+
+    uint8_t two_bit = (encryption_and_authentication_challenge[TFA_VERIFY_BYTEPOS] >>
+                       (SIZE_BYTE - 2 *
+                        TFA_VERIFY_BITPOS)) & 3;
+
+    TFA_VERIFY_BITPOS = (TFA_VERIFY_BITPOS + 1) % 5;
+    if (TFA_VERIFY_BITPOS == 0) {
+        TFA_VERIFY_BYTEPOS = (TFA_VERIFY_BYTEPOS + 1) % SIZE_ECDH_SHARED_SECRET;
+        TFA_VERIFY_BITPOS = 1;
+    }
+    led_code(two_bit + 1);
+
+    utils_zero(encryption_and_authentication_key, SHA512_DIGEST_LENGTH);
+    utils_zero(encryption_and_authentication_challenge, SHA256_DIGEST_LENGTH);
+
+    commander_fill_report(cmd_str(CMD_ecdh), attr_str(ATTR_success), DBB_JSON_STRING);
+}
+
+/**
+ * Aborts the pairing process and thereby resets the positions for blinking.
+ */
+static void ecdh_abort_command(void)
+{
+    utils_zero(TFA_IN_HASH_PUB, SHA256_DIGEST_LENGTH);
+    utils_zero(&tfa_keypair, sizeof(TFA_EC_Keypair));
+    utils_clear_buffers();
+    TFA_VERIFY_BITPOS = 1;
+    TFA_VERIFY_BYTEPOS = 0;
+    commander_fill_report(cmd_str(CMD_ecdh), cmd_str(ATTR_aborted), DBB_JSON_STRING);
+}
+
+/**
+ * Dispatches the ecdh command. The following commands are accepted:
+ *
+ * { "ecdh" : { "hash_pubkey" : "..." } }
+ * { "ecdh" : { "pubkey" : "..." } }
+ * { "ecdh" : { "challenge" : true } }
+ * { "ecdh" : { "abort" : true } }
+ */
+void ecdh_dispatch_command(yajl_val json_node)
+{
+    const char *value_path[] = { cmd_str(CMD_ecdh), NULL };
+
+    yajl_val data = yajl_tree_get(json_node, value_path, yajl_t_any);
+
+    if (YAJL_IS_OBJECT(data)) {
+        const char *pair_hash_pubkey_path[] = { cmd_str(CMD_hash_pubkey), NULL };
+        const char *pair_hash_pubkey = YAJL_GET_STRING(yajl_tree_get(data, pair_hash_pubkey_path,
+                                       yajl_t_string));
+
+        const char *pair_pubkey_path[] = { cmd_str(CMD_pubkey), NULL };
+        const char *pair_pubkey = YAJL_GET_STRING(yajl_tree_get(data, pair_pubkey_path,
+                                  yajl_t_string));
+
+        const char *pair_challenge_path[] = { cmd_str(CMD_challenge), NULL };
+        yajl_val pair_challenge = yajl_tree_get(data, pair_challenge_path, yajl_t_true);
+
+        const char *pair_abort_path[] = { cmd_str(CMD_abort), NULL };
+        yajl_val pair_abort = yajl_tree_get(data, pair_abort_path, yajl_t_true);
+
+        if (strlens(pair_hash_pubkey)) {
+            ecdh_hash_pubkey_command(pair_hash_pubkey);
+        } else if (strlens(pair_pubkey)) {
+            ecdh_pubkey_command(pair_pubkey);
+        } else if (YAJL_IS_TRUE(pair_challenge)) {
+            ecdh_challenge_command();
+        } else if (YAJL_IS_TRUE(pair_abort)) {
+            ecdh_abort_command();
+        } else {
+            commander_fill_report(cmd_str(CMD_ecdh), NULL, DBB_ERR_IO_INVALID_CMD);
+        }
+    } else {
+        commander_fill_report(cmd_str(CMD_ecdh), NULL, DBB_ERR_IO_INVALID_CMD);
+    }
+}

--- a/src/ecdh.h
+++ b/src/ecdh.h
@@ -2,7 +2,7 @@
 
  The MIT License (MIT)
 
- Copyright (c) 2015-2016 Douglas J. Bakkum
+ Copyright (c) 2015-2018 Douglas J. Bakkum, Stephanie Stroka, Shift Cryptosecurity
 
  Permission is hereby granted, free of charge, to any person obtaining
  a copy of this software and associated documentation files (the "Software"),
@@ -24,24 +24,16 @@
 
 */
 
-
-#ifndef _LED_H_
-#define _LED_H_
-
+#ifndef _ECDH_H_
+#define _ECDH_H_
 
 #include <stdint.h>
 
+#include "yajl/src/api/yajl_tree.h"
 
-#define LED_MAX_CODE_BLINKS 4
-#define LED_MAX_BLINK_SETS  6
+#define SIZE_ECDH_SHARED_SECRET SHA256_DIGEST_LENGTH
 
-
-void led_on(void);
-void led_off(void);
-void led_toggle(void);
-void led_blink(void);
-void led_abort(void);
-void led_code(uint8_t code);
-
+void ecdh_dispatch_command(yajl_val json_node);
 
 #endif
+

--- a/src/flags.h
+++ b/src/flags.h
@@ -36,10 +36,9 @@
 #define COMMANDER_ARRAY_ELEMENT_MAX 1024
 #define COMMANDER_MAX_ATTEMPTS      15// max PASSWORD or LOCK PIN attempts before device reset
 #define COMMANDER_TOUCH_ATTEMPTS    10// number of attempts until touch button hold required to login
-#define VERIFYPASS_FILENAME         "verification.pdf"
 #define VERIFYPASS_CRYPT_TEST       "Digital Bitbox 2FA"
-#define VERIFYPASS_LOCK_CODE_LEN    16// bytes
-#define DEVICE_DEFAULT_NAME         "My Digital Bitbox"
+#define TFA_PIN_LEN                 16// bytes
+#define DEVICE_DEFAULT_NAME         "My BitBox"
 #define SD_FILEBUF_LEN_MAX          (COMMANDER_REPORT_SIZE * 4 / 7)
 #define AES_DATA_LEN_MAX            (COMMANDER_REPORT_SIZE * 4 / 7)// base64 increases size by ~4/3; AES encryption by max 32 char
 #define PASSWORD_LEN_MIN            4
@@ -67,6 +66,9 @@ X(led)            \
 X(xpub)           \
 X(name)           \
 X(ecdh)           \
+X(hash_pubkey)    \
+X(abort)          \
+X(challenge)      \
 X(device)         \
 X(random)         \
 X(backup)         \
@@ -180,6 +182,7 @@ X(JSON_STRING,           0, 0)\
 X(JSON_BOOL,             0, 0)\
 X(JSON_ARRAY,            0, 0)\
 X(JSON_NUMBER,           0, 0)\
+X(JSON_OBJECT,           0, 0)\
 X(JSON_NONE,             0, 0)\
 /* placeholder don't move  */ \
 X(FLAG_ERROR_START,      0, 0)\
@@ -205,6 +208,9 @@ X(ERR_KEY_MASTER,      250, "Master key not present.")\
 X(ERR_KEY_CHILD,       251, "Could not generate key.")\
 X(ERR_KEY_ECDH,        252, "Could not generate ECDH secret.")\
 X(ERR_KEY_ECDH_LEN,    253, "Incorrect serialized pubkey length. A 33-byte hexadecimal value (66 characters) is expected.")\
+X(ERR_KEY_HASH_ECDH_LEN, 254, "Incorrect serialized pubkey hash length. A 32-byte hexadecimal value (64 characters) is expected.")\
+X(ERR_TFA_HASH_MISSING, 255, "Failed to pair with second factor, because the hash of the public key was not received.")\
+X(ERR_TFA_HASH_MATCH,  256, "Failed to pair with second factor, because the previously received hash of the public key does not match the computed hash of the public key.")\
 X(ERR_SIGN_PUBKEY_LEN, 300, "Incorrect pubkey length. A 33-byte hexadecimal value (66 characters) is expected.")\
 X(ERR_SIGN_HASH_LEN,   301, "Incorrect hash length. A 32-byte hexadecimal value (64 characters) is expected.")\
 X(ERR_SIGN_DESERIAL,   302, "Could not deserialize outputs or wrong change keypath.")\

--- a/src/flash.c
+++ b/src/flash.c
@@ -87,7 +87,7 @@ uint32_t flash_erase_page(uint32_t ul_address, uint8_t uc_page_num)
 
 
 uint32_t flash_write(uint32_t ul_address, const void *p_buffer,
-		uint32_t ul_size, uint32_t ul_erase_flag)
+                     uint32_t ul_size, uint32_t ul_erase_flag)
 {
     uint32_t i;
     uint8_t buf[FLASH_SIG_LEN];

--- a/src/flash.h
+++ b/src/flash.h
@@ -96,8 +96,14 @@ static inline uint32_t mpu_region_size(uint32_t size)
 
 
 #ifdef TESTING
-static void HardFault_Handler(void) { exit(1); }
-static void MemManage_Handler(void) { exit(2); }
+static void HardFault_Handler(void)
+{
+    exit(1);
+}
+static void MemManage_Handler(void)
+{
+    exit(2);
+}
 
 uint8_t flash_read_unique_id(uint32_t *serial, uint32_t len);
 uint32_t flash_erase_user_signature(void);
@@ -105,7 +111,7 @@ uint32_t flash_write_user_signature(const void *p_buffer, uint32_t ul_size);
 uint32_t flash_read_user_signature(uint32_t *p_data, uint32_t ul_size);
 uint32_t flash_erase_page(uint32_t ul_address, uint8_t uc_page_num);
 uint32_t flash_write(uint32_t ul_address, const void *p_buffer,
-		uint32_t ul_size, uint32_t ul_erase_flag);
+                     uint32_t ul_size, uint32_t ul_erase_flag);
 #endif
 void flash_read_sig_area(uint8_t *sig, uint32_t ul_address, uint32_t len);
 

--- a/src/led.c
+++ b/src/led.c
@@ -74,7 +74,10 @@ void led_toggle(void)
     ioport_set_pin_level(LED_0_PIN, !ioport_get_pin_level(LED_0_PIN));
 }
 
-
+/**
+ * Blink the LED.
+ * Do not expose this function via API (to prevent possible security problems during TFA pairing).
+ */
 void led_blink(void)
 {
     led_on();
@@ -87,26 +90,23 @@ void led_abort(void)
 {
     led_off();
     delay_ms(300);
-    led_on();
-    delay_ms(100);
-    led_off();
-    delay_ms(100);
-    led_on();
-    delay_ms(100);
-    led_off();
+    for (int i = 0; i < 6; i++) {
+        led_on();
+        delay_ms(100);
+        led_off();
+        delay_ms(100);
+    }
 }
 
-void led_code(uint8_t *code, uint8_t len)
+void led_code(uint8_t code)
 {
-    uint8_t i, j;
+    uint8_t i;
     delay_ms(500);
-    for (i = 0; i < len; i++) {
-        for (j = 0; j < code[i]; j++) {
-            led_toggle();
-            delay_ms(300);
-            led_toggle();
-            delay_ms(300);
-        }
-        delay_ms(500);
+    for (i = 0; i < code; i++) {
+        led_toggle();
+        delay_ms(300);
+        led_toggle();
+        delay_ms(300);
     }
+    delay_ms(500);
 }

--- a/src/memory.h
+++ b/src/memory.h
@@ -46,7 +46,7 @@
 #define MEM_MASTER_BIP32_ADDR           0x0200
 #define MEM_MASTER_BIP32_CHAIN_ADDR     0x0300
 #define MEM_AESKEY_STAND_ADDR           0x0400
-#define MEM_AESKEY_VERIFY_ADDR          0x0500
+#define MEM_AESKEY_SHARED_SECRET_ADDR   0x0500
 #define MEM_AESKEY_Z6_ADDR              0x0600// Zone 6 reserved first 32*4 bytes
 #define MEM_AESKEY_Z7_ADDR              0x0700// Zone 7 reserved
 #define MEM_AESKEY_HIDDEN_ADDR          0x0800
@@ -57,7 +57,7 @@
 
 
 // Extension flags
-#define MEM_EXT_MASK_U2F         0x00000001// Mask of bit to enable (1) or disable (0) U2F functions 
+#define MEM_EXT_MASK_U2F         0x00000001// Mask of bit to enable (1) or disable (0) U2F functions
 // Will override and disable U2F_HIJACK bit when disabled
 #define MEM_EXT_MASK_U2F_HIJACK  0x00000002// Mask of bit to enable (1) or disable (0) U2F_HIJACK interface
 
@@ -73,7 +73,7 @@
 typedef enum PASSWORD_ID {
     PASSWORD_STAND,
     PASSWORD_HIDDEN,
-    PASSWORD_VERIFY,
+    TFA_SHARED_SECRET,
     PASSWORD_NONE  /* keep last */
 } PASSWORD_ID;
 
@@ -87,6 +87,7 @@ void memory_clear(void);
 
 void memory_active_key_set(uint8_t *key);
 uint8_t *memory_active_key_get(void);
+uint8_t memory_write_tfa_shared_secret(const uint8_t *secret);
 uint8_t memory_write_aeskey(const char *password, int len, PASSWORD_ID id);
 void memory_read_aeskeys(void);
 uint8_t *memory_report_aeskey(PASSWORD_ID id);

--- a/src/sharedsecret.c
+++ b/src/sharedsecret.c
@@ -2,7 +2,7 @@
 
  The MIT License (MIT)
 
- Copyright (c) 2015-2016 Douglas J. Bakkum
+ Copyright (c) 2015-2018 Douglas J. Bakkum
 
  Permission is hereby granted, free of charge, to any person obtaining
  a copy of this software and associated documentation files (the "Software"),
@@ -24,24 +24,24 @@
 
 */
 
-
-#ifndef _LED_H_
-#define _LED_H_
-
-
 #include <stdint.h>
 
+#include "sha2.h"
+#include "utils.h"
+#include "sharedsecret.h"
 
-#define LED_MAX_CODE_BLINKS 4
-#define LED_MAX_BLINK_SETS  6
+void sharedsecret_derive_keys(const uint8_t *shared_secret, uint8_t *encryption_key,
+                              uint8_t *authentication_key)
+{
+    uint8_t encryption_and_authentication_key[SHA512_DIGEST_LENGTH];
+    sha512_Raw(shared_secret, SHA256_DIGEST_LENGTH, encryption_and_authentication_key);
+
+    int KEY_SIZE = SHA512_DIGEST_LENGTH / 2;
+
+    memcpy(encryption_key, encryption_and_authentication_key, KEY_SIZE);
+    memcpy(authentication_key, encryption_and_authentication_key + KEY_SIZE, KEY_SIZE);
+
+    utils_zero(encryption_and_authentication_key, SHA512_DIGEST_LENGTH);
+}
 
 
-void led_on(void);
-void led_off(void);
-void led_toggle(void);
-void led_blink(void);
-void led_abort(void);
-void led_code(uint8_t code);
-
-
-#endif

--- a/src/sharedsecret.h
+++ b/src/sharedsecret.h
@@ -2,7 +2,7 @@
 
  The MIT License (MIT)
 
- Copyright (c) 2015-2016 Douglas J. Bakkum
+ Copyright (c) 2015-2018 Douglas J. Bakkum
 
  Permission is hereby granted, free of charge, to any person obtaining
  a copy of this software and associated documentation files (the "Software"),
@@ -24,24 +24,10 @@
 
 */
 
+#ifndef _SHAREDSECRET_H_
+#define _SHAREDSECRET_H_
 
-#ifndef _LED_H_
-#define _LED_H_
-
-
-#include <stdint.h>
-
-
-#define LED_MAX_CODE_BLINKS 4
-#define LED_MAX_BLINK_SETS  6
-
-
-void led_on(void);
-void led_off(void);
-void led_toggle(void);
-void led_blink(void);
-void led_abort(void);
-void led_code(uint8_t code);
-
+void sharedsecret_derive_keys(const uint8_t *shared_secret, uint8_t *encryption_key,
+                              uint8_t *authentication_key);
 
 #endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -37,6 +37,9 @@
 static uint8_t utils_buffer[UTILS_BUFFER_LEN];
 
 
+/**
+ * Sets len 0s into the given memory at address dst.
+ */
 volatile void *utils_zero(volatile void *dst, size_t len)
 {
     volatile char *buf;

--- a/src/utils.h
+++ b/src/utils.h
@@ -29,6 +29,7 @@
 #define _UTILS_H_
 
 
+#include <string.h>
 #include <stdint.h>
 #include <stddef.h>
 #include "memory.h"

--- a/tests/api.h
+++ b/tests/api.h
@@ -36,6 +36,8 @@
 #include "u2f/u2f.h"
 #include "u2f_device.h"
 #include "commander.h"
+#include "aescbcb64.h"
+#include "random.h"
 #include "utest.h"
 #include "usb.h"
 
@@ -105,8 +107,8 @@ static void api_decrypt_report(const char *report, uint8_t *key)
         const char *ciphertext = YAJL_GET_STRING(yajl_tree_get(json_node, ciphertext_path,
                                  yajl_t_string));
         if (ciphertext) {
-            dec = aes_cbc_b64_decrypt((const unsigned char *)ciphertext, strlens(ciphertext),
-                                      &decrypt_len, key);
+            dec = aescbcb64_decrypt((const unsigned char *)ciphertext, strlens(ciphertext),
+                                    &decrypt_len, key);
             if (!dec) {
                 strcpy(decrypted_report, "/* error: Failed to decrypt. */");
                 goto exit;
@@ -391,7 +393,7 @@ static void api_hid_send(const char *cmd)
 static void api_hid_send_encrypt(const char *cmd, uint8_t *key)
 {
     int enc_len;
-    char *enc = aes_cbc_b64_encrypt((const unsigned char *)cmd, strlens(cmd), &enc_len, key);
+    char *enc = aescbcb64_encrypt((const unsigned char *)cmd, strlens(cmd), &enc_len, key);
     api_hid_send_len(enc, enc_len);
     free(enc);
 }
@@ -479,8 +481,8 @@ static char *api_read_value_decrypt(int cmd, uint8_t *key)
     memset(val_dec, 0, sizeof(val_dec));
 
     int decrypt_len;
-    char *dec = aes_cbc_b64_decrypt((const unsigned char *)val, strlens(val),
-                                    &decrypt_len, key);
+    char *dec = aescbcb64_decrypt((const unsigned char *)val, strlens(val),
+                                  &decrypt_len, key);
 
     snprintf(val_dec, HID_REPORT_SIZE, "%.*s", decrypt_len, dec);
     free(dec);

--- a/tests/hmac_check.h
+++ b/tests/hmac_check.h
@@ -1,0 +1,106 @@
+/*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2018 Douglas J. Bakkum, Stephanie Stroka, Shift Cryptosecurity
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+
+#ifndef _HMAC_CHECK_H_
+#define _HMAC_CHECK_H_
+
+
+#include <stdint.h>
+#include "yajl/src/api/yajl_tree.h"
+#include "sharedsecret.h"
+#include "aescbcb64.h"
+#include "base64.h"
+#include "flags.h"
+#include "utils.h"
+#include "utest.h"
+#include "hmac.h"
+#include "sha2.h"
+#include "aes.h"
+
+
+/**
+ * Performs an hmac sha256 message integrity check and returns 0 if the integrity check
+ * failed and 1 if it succeeded.
+ */
+static int check_hmac_sha256(const uint8_t *key, const uint32_t keylen,
+                             const unsigned char *in,
+                             const unsigned int length, const uint8_t *hmac)
+{
+    uint8_t verify_hmac[SHA256_DIGEST_LENGTH];
+    hmac_sha256(key, keylen, in, length, verify_hmac);
+    if (MEMEQ(hmac, verify_hmac, SHA256_DIGEST_LENGTH)) {
+        return 1;
+    }
+    return 0;
+}
+
+
+static char *decrypt_and_check_hmac(const unsigned char *in, int inlen, int *out_msg_len,
+                                    const uint8_t *shared_secret, uint8_t *out_hmac)
+{
+    if (!in || inlen == 0) {
+        return NULL;
+    }
+
+    uint8_t encryption_key[SHA256_DIGEST_LENGTH];
+    uint8_t authentication_key[SHA256_DIGEST_LENGTH];
+
+    sharedsecret_derive_keys(shared_secret, encryption_key, authentication_key);
+
+    // Unbase64
+    int ub64len;
+    unsigned char *ub64 = unbase64((const char *)in, inlen, &ub64len);
+    if (!ub64) {
+        return NULL;
+    }
+    if ((ub64len % N_BLOCK) || ub64len < N_BLOCK) {
+        memset(ub64, 0, ub64len);
+        free(ub64);
+        return NULL;
+    }
+
+    memcpy(out_hmac, ub64 + (ub64len - SHA256_DIGEST_LENGTH), SHA256_DIGEST_LENGTH);
+    int hmac_len = ub64len - SHA256_DIGEST_LENGTH;
+
+    char *decrypted = NULL;
+    if (check_hmac_sha256(authentication_key, SHA256_DIGEST_LENGTH, ub64, hmac_len,
+                          out_hmac)) {
+        decrypted = aescbcb64_init_and_decrypt(ub64,
+                                               ub64len - SHA256_DIGEST_LENGTH,
+                                               out_msg_len,
+                                               encryption_key);
+    }
+
+    memset(ub64, 0, ub64len);
+    free(ub64);
+    utils_zero(encryption_key, sizeof(encryption_key));
+    utils_zero(authentication_key, sizeof(authentication_key));
+    return decrypted;
+}
+
+
+#endif


### PR DESCRIPTION
Update pairing between device and mobile app and use an hmac. The ECDH code is removed from `commander.c` and put into `ecdh.c`. The led abort command was deprecated while the led blink command was modified to blink 5 times quickly.