### PR TITLE
docker: adds script to start docker with volume

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -17,9 +17,6 @@
 #
 
 FROM debian:stretch
-ENV DEBIAN_FRONTEND noninteractive
-WORKDIR /app
-COPY . /app
 
 RUN apt update && apt-get install -y cmake git gcc-arm-none-eabi locales python python-pip
 RUN apt install -y libbz2-1.0 libncurses5 libz1 valgrind astyle clang libudev-dev python-urllib3 libssl1.0-dev
@@ -27,5 +24,5 @@ RUN apt install -y libbz2-dev libbz2-dev libbz2-1.0 libncurses5 libz1 valgrind a
 RUN pip install --prefix /usr/local  cpp-coveralls
 RUN locale-gen UTF-8
 ENV CC gcc
-RUN cd /app/ && mkdir docker-build && cd docker-build && cmake .. -DBUILD_TYPE=firmware -DUSE_SECP256K1_LIB=ON && make TEST=yes
-RUN sha256sum docker-build/bin/*
+
+CMD ["bash"]

--- a/Dockerfile.tests
+++ b/Dockerfile.tests
@@ -21,7 +21,6 @@ ENV DEBIAN_FRONTEND noninteractive
 WORKDIR /app
 COPY . /app
 
-
 RUN gcc -v
 RUN clang -v
 ENV CC gcc

--- a/dockerdev.sh
+++ b/dockerdev.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -e
+# Copyright 2018 Shift Devices AG
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+dockerdev () {
+    local container_image=shift/mcu-base
+    local container_name=mcu-dev
+
+    if ! docker images | grep -q $container_image; then
+        echo "No $container_image docker image found! Maybe you need to run 'docker build --tag $container_image -f Dockerfile.dev .'?" >&2
+        exit 1
+    fi
+
+    # If already running, enter the container.
+    if docker ps | grep -q $container_name; then
+        docker exec -it $container_name bash
+        return
+    fi
+
+    if docker ps -a | grep -q $container_name; then
+        docker rm $container_name
+    fi
+
+    local repo_path="$DIR"
+    docker run \
+           --detach \
+           --privileged -v /dev/bus/usb:/dev/bus/usb \
+           --interactive --tty \
+           --name=$container_name \
+           -v $repo_path:/app \
+           $container_image bash
+
+    # Call a second time to enter the container.
+    dockerdev
+}
+
+dockerdev


### PR DESCRIPTION
dockerdev.sh starts the docker container based on shift/mcu-base with thir
directory as a volume. This commit also removed the copy workspace and build
commands from the Dockerfile.dev, since this is not needed any longer. When
using volumes, one can easily access files produced in the docker container and
the docker container can see updates in the volumes, which means that the image
doesn't have to be re-built to produce a firmware binary.