### PR TITLE
return firmware version in ping

### DIFF
--- a/src/commander.c
+++ b/src/commander.c
@@ -1576,6 +1576,10 @@ static int commander_check_init(const char *encrypted_command)
                 } else {
                     commander_fill_report(cmd_str(CMD_ping), attr_str(ATTR_password), DBB_OK);
                 }
+                char device_info[100];
+                snprintf(device_info, sizeof(device_info),
+                        "{\"%s\":\"%s\"}", attr_str(ATTR_version), DIGITAL_BITBOX_VERSION);
+                commander_fill_report(cmd_str(CMD_device), device_info, DBB_JSON_OBJECT);
                 yajl_tree_free(json_node);
                 return DBB_ERROR;
             }

--- a/tests/tests_api.c
+++ b/tests/tests_api.c
@@ -45,6 +45,7 @@
 #include "secp256k1/include/secp256k1_recovery.h"
 
 #include "api.h"
+#include "version.h"
 
 
 #define HASH_DEFAULT       "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
@@ -1350,12 +1351,18 @@ static void tests_device(void)
 
     api_format_send_cmd(cmd_str(CMD_ping), "", NULL);
     ASSERT_REPORT_HAS(attr_str(ATTR_false));
+    ASSERT_REPORT_HAS(cmd_str(CMD_device));
+    ASSERT_REPORT_HAS(attr_str(ATTR_version));
+    ASSERT_REPORT_HAS(DIGITAL_BITBOX_VERSION);
 
     api_format_send_cmd(cmd_str(CMD_password), tests_pwd, NULL);
     ASSERT_SUCCESS;
 
     api_format_send_cmd(cmd_str(CMD_ping), "", NULL);
     ASSERT_REPORT_HAS(attr_str(ATTR_password));
+    ASSERT_REPORT_HAS(cmd_str(CMD_device));
+    ASSERT_REPORT_HAS(attr_str(ATTR_version));
+    ASSERT_REPORT_HAS(DIGITAL_BITBOX_VERSION);
 
     api_format_send_cmd(cmd_str(CMD_led), attr_str(ATTR_blink), KEY_STANDARD);
     ASSERT_SUCCESS;


### PR DESCRIPTION
The plaintext ping response now includes the firmware version, same
format as in the response of the device info command.

Useful if one does not have access to the usb descriptor, e.g. when
communication using u2f.