### PR TITLE
add 'pairing' to feature_set

### DIFF
--- a/src/flags.h
+++ b/src/flags.h
@@ -151,6 +151,7 @@ X(U2F_load)       \
 X(U2F_create)     \
 X(U2F_hijack)     \
 X(new_hidden_wallet)    \
+X(pairing)        \
 X(__ERASE__)      \
 X(__FORCE__)      \
 X(NUM)             /* keep last */

--- a/src/memory.h
+++ b/src/memory.h
@@ -34,6 +34,7 @@
 #define MEM_EXT_MASK_U2F               0x00000001 // Mask of bit to enable (1) or disable (0) U2F functions; will override and disable U2F_HIJACK bit when disabled
 #define MEM_EXT_MASK_U2F_HIJACK        0x00000002 // Mask of bit to enable (1) or disable (0) U2F_HIJACK interface
 #define MEM_EXT_MASK_NEW_HIDDEN_WALLET 0x00000004 // Mask of bit to enable (1) or disable (0) the new hidden wallet derivation
+#define MEM_EXT_MASK_NOTPAIRED         0x00000008 // Mask of bit to disable (1) or enable (0) pairing
 // Default settings
 #define MEM_DEFAULT_unlocked            0xFF
 #define MEM_DEFAULT_erased              0xFF

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -66,6 +66,10 @@ int wallet_is_locked(void)
     return HIDDEN || !memory_read_unlocked();
 }
 
+int wallet_is_paired(void)
+{
+    return wallet_is_locked() || !(memory_report_ext_flags() & MEM_EXT_MASK_NOTPAIRED);
+}
 
 uint8_t *wallet_get_master(void)
 {

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -37,6 +37,7 @@
 void wallet_set_hidden(int hide);
 int wallet_is_hidden(void);
 int wallet_is_locked(void);
+int wallet_is_paired(void);
 uint8_t *wallet_get_master(void);
 uint8_t *wallet_get_chaincode(void);
 int wallet_split_seed(char **seed_words, const char *message);


### PR DESCRIPTION
Can only enable. Always enabled when device is locked (backwards
compatible with full 2FA). Disabled by default.