### PR TITLE
whitelist keypaths; require reset before reseeding

### DIFF
--- a/src/flags.h
+++ b/src/flags.h
@@ -205,6 +205,7 @@ X(ERR_SEED_SD,         200, "Seed creation requires an SD card for automatic enc
 X(ERR_SEED_SD_NUM,     201, "Too many backup files. Please remove one from the SD card.")\
 X(ERR_SEED_MEM,        202, "Could not allocate memory for seed.")\
 X(ERR_SEED_INVALID,    204, "Invalid seed.")\
+X(ERR_SEED_SEEDED,     205, "Wallet is seeded. Reset to continue.")\
 X(ERR_KEY_MASTER,      250, "Master key not present.")\
 X(ERR_KEY_CHILD,       251, "Could not generate key.")\
 X(ERR_KEY_ECDH,        252, "Could not generate ECDH secret.")\
@@ -240,6 +241,7 @@ X(WARN_RESET,          900, "attempts remain before the device is reset.")\
 X(WARN_NO_MCU,         901, "Ignored for non-embedded testing.")\
 X(WARN_SD_NUM_FILES,   902, "Too many backup files to read. The list is truncated.")\
 X(WARN_RESET_TOUCH,    903, "attempts remain before the device is reset. The next login requires holding the touch button.")\
+X(WARN_KEYPATH,        904, "Non-standard keypath.")\
 X(FLAG_NUM,              0, 0)/* keep last */
 
 

--- a/src/flash.c
+++ b/src/flash.c
@@ -131,7 +131,7 @@ uint32_t flash_wrapper_erase_page(uint32_t ul_address, uint8_t uc_page_num)
 
 
 uint32_t flash_wrapper_write(uint32_t ul_address, void *p_buffer,
-                  uint32_t ul_size, uint32_t ul_erase_flag)
+                             uint32_t ul_size, uint32_t ul_erase_flag)
 {
 #ifdef TESTING
     uint32_t i;

--- a/src/sd.c
+++ b/src/sd.c
@@ -54,7 +54,7 @@ static char ROOTDIR[] = "tests/digitalbitbox";// If change, update tests/CMakeLi
 #else
 static char ROOTDIR[256]; // 255 char path
 
-void set_root_dir(const char* path)
+void set_root_dir(const char *path)
 {
     memset(ROOTDIR, 0, sizeof(ROOTDIR));
     snprintf(ROOTDIR, sizeof(ROOTDIR), "%s", path);

--- a/src/sd.h
+++ b/src/sd.h
@@ -69,7 +69,7 @@ char *sd_load(const char *fn, int cmd);
 uint8_t sd_write(const char *fn, const char *wallet_backup, const char *wallet_name,
                  const char *u2f_backup, uint8_t replace, int cmd);
 #ifdef SIMULATOR
-void set_root_dir(const char* path);
+void set_root_dir(const char *path);
 #endif
 
 

--- a/src/simulator.c
+++ b/src/simulator.c
@@ -12,7 +12,7 @@
 #define PORT 35345
 #define BUF_SIZE COMMANDER_REPORT_SIZE
 
-int main(int argc, char* argv[])
+int main(int argc, char *argv[])
 {
     // Get and set the root directory
     if (argc < 2) {
@@ -47,7 +47,7 @@ int main(int argc, char* argv[])
     sock.sin_port = htons(PORT);
 
     // Bind socket
-    if (bind(s, (struct sockaddr*)&sock, sizeof(sock)) == -1) {
+    if (bind(s, (struct sockaddr *)&sock, sizeof(sock)) == -1) {
         fprintf(stderr, "Could not bind socket\n");
         exit(1);
     }
@@ -55,7 +55,7 @@ int main(int argc, char* argv[])
 
     // Wait for connections and handle
     char buf[BUF_SIZE];
-    char* result;
+    char *result;
     struct sockaddr_in in_sock;
     int recv_len;
     socklen_t in_sock_len = sizeof(in_sock);
@@ -63,7 +63,8 @@ int main(int argc, char* argv[])
         int rc;
         // Receive
         memset(buf, 0, BUF_SIZE);
-        if ((recv_len = recvfrom(s, buf, BUF_SIZE, 0, (struct sockaddr*)&in_sock, &in_sock_len)) < 0) {
+        if ((recv_len = recvfrom(s, buf, BUF_SIZE, 0, (struct sockaddr *)&in_sock,
+                                 &in_sock_len)) < 0) {
             fprintf(stderr, "Failed to receive udp data, error %d\n", recv_len);
             exit(1);
         }
@@ -72,7 +73,8 @@ int main(int argc, char* argv[])
         result = commander(buf);
 
         // Send result to socket
-        if ((rc = sendto(s, result, strlen(result), 0, (struct sockaddr*)&in_sock, in_sock_len)) < 0) {
+        if ((rc = sendto(s, result, strlen(result), 0, (struct sockaddr *)&in_sock,
+                         in_sock_len)) < 0) {
             fprintf(stderr, "Failed to send udp data, error %d\n", rc);
             exit(1);
         }

--- a/src/wallet.h
+++ b/src/wallet.h
@@ -33,6 +33,23 @@
 #include "bip32.h"
 
 
+// BIP44 keypath whitelist for the xpub command
+// m / purpose' / coin_type' / account' / change / address_index
+#define BIP44_PURPOSE_HARDENED true
+#define BIP44_PURPOSE_P2PKH 44 // BIP44 legacy
+#define BIP44_PURPOSE_P2WPKH_P2SH 49 // BIP49 segwit nested in pay to script hash
+#define BIP44_PURPOSE_P2WPKH 84 // BIP84 native segwit
+#define BIP44_COIN_TYPE_HARDENED true
+#define BIP44_COIN_TYPE_BTC 0
+#define BIP44_COIN_TYPE_TESTNET 1
+#define BIP44_COIN_TYPE_LTC 2
+#define BIP44_ACCOUNT_HARDENED true
+#define BIP44_ACCOUNT_MAX 9// 10 accounts (0:9)
+#define BIP44_CHANGE_HARDENED false
+#define BIP44_CHANGE_MAX 0// A client is not expected to request an xpub on a change path
+#define BIP44_ADDRESS_HARDENED false
+#define BIP44_ADDRESS_MAX 999999// 1M accounts (0:999999)
+
 /* BIP32 */
 void wallet_set_hidden(int hide);
 int wallet_is_hidden(void);
@@ -46,7 +63,7 @@ int wallet_erased(void);
 int wallet_create(const char *passphrase, const char *entropy_in);
 int wallet_check_pubkey(const char *pubkey, const char *keypath);
 int wallet_sign(const char *message, const char *keypath);
-void wallet_report_xpub(const char *keypath, char *xpub);
+int wallet_report_xpub(const char *keypath, char *xpub);
 void wallet_report_id(char *id);
 int wallet_generate_key(HDNode *node, const char *keypath, const uint8_t *privkeymaster,
                         const uint8_t *chaincode);

--- a/tests/tests_u2f_standard.c
+++ b/tests/tests_u2f_standard.c
@@ -304,7 +304,8 @@ static void check_CounterUpdate(void)
              "{\"source\":\"create\", \"filename\":\"hwwcountertest.pdf\", \"key\":\"key\"}");
     api_format_send_cmd(cmd_str(CMD_seed), cmd, KEY_STANDARD);
     ASSERT_SUCCESS;
-    api_format_send_cmd(cmd_str(CMD_backup), "{\"erase\":\"hwwcountertest.pdf\"}", KEY_STANDARD);
+    api_format_send_cmd(cmd_str(CMD_backup), "{\"erase\":\"hwwcountertest.pdf\"}",
+                        KEY_STANDARD);
 
     if (U2Fob_liveDeviceTesting()) {
         PRINT_MESSAGE("Creating new U2F key. LONG touch to continue...\n");
@@ -333,7 +334,8 @@ static void check_CounterUpdate(void)
              c);
     api_format_send_cmd(cmd_str(CMD_seed), cmd, KEY_STANDARD);
     ASSERT_SUCCESS;
-    api_format_send_cmd(cmd_str(CMD_backup), "{\"erase\":\"u2fcountertest.pdf\"}", KEY_STANDARD);
+    api_format_send_cmd(cmd_str(CMD_backup), "{\"erase\":\"u2fcountertest.pdf\"}",
+                        KEY_STANDARD);
 
     // Ctr should be c + 1.
     WaitForUserPresence(device, arg_hasButton);


### PR DESCRIPTION
- xpub API: send back a warning and do not echo if using a non-whitelisted keypath in order to match keypaths supported by the mobile app.
- Require reset before hardware wallet seed creation or recovery from backup. This matches what is already done in the desktop app.
- astyle styling for previous commits