### PR TITLE
update u2f hijack whitelist for vintage MEW and latest Chrome

### DIFF
--- a/src/u2f_device.c
+++ b/src/u2f_device.c
@@ -65,26 +65,32 @@
 static uint32_t cid = 0;
 volatile bool u2f_state_continue = false;
 volatile uint16_t u2f_current_time_ms = 0;
-const uint8_t U2F_HIJACK_CODE[U2F_HIJACK_ORIGIN_TOTAL][U2F_NONCE_LENGTH] = {
+const uint8_t U2F_HIJACK_CODE[U2F_HIJACK_ORIGIN_TOTAL][U2F_APPID_SIZE] = {
     {
         /* Corresponds to U2F client challenge filled with `0xdb` */
         /* Origin `https://digitalbitbox.com` */
-        57,   55, 173, 209, 178, 255, 144, 175,
-        24,  190, 240, 197, 183,  84,  22, 170,
-        58,  118, 133,  98, 243, 145, 238, 136,
-        137, 134, 248,  90, 247, 202, 114, 148
+        0x17, 0x9d, 0xc3, 0x1c, 0x3a, 0xd4, 0x0f, 0x05,
+        0xf0, 0x71, 0x71, 0xed, 0xf4, 0x46, 0x4a, 0x71,
+        0x0a, 0x2d, 0xd4, 0xde, 0xc7, 0xe6, 0x14, 0x41,
+        0xc5, 0xbd, 0x24, 0x97, 0x8a, 0x99, 0x2a, 0x1a,
     }, {
         /* Origin `https://www.myetherwallet.com` */
-        240,  97, 125, 208,  85, 124, 251, 127,
-        247, 228, 158, 226, 243,  43,  46,  47,
-        60,  196, 229, 129, 113, 218, 237, 220,
-        200, 151, 111, 248,  63, 168, 101,  51
+        0x8e, 0x57, 0xf6, 0x48, 0xb9, 0x1b, 0x24, 0xfe,
+        0x27, 0x92, 0x3a, 0x75, 0xef, 0xa1, 0xd0, 0x62,
+        0xdc, 0xb5, 0x4d, 0x41, 0xfd, 0x0b, 0xee, 0x33,
+        0x9e, 0xf2, 0xa2, 0xb4, 0x55, 0x0c, 0xbe, 0x05,
+    }, {
+        /* Origin `https://vintage.myetherwallet.com` */
+        0x0f, 0x5b, 0x76, 0xef, 0x29, 0x8f, 0x15, 0x0b,
+        0x4d, 0x39, 0x9d, 0x2c, 0x3c, 0xb9, 0x0e, 0x86,
+        0x54, 0xa3, 0x7c, 0x60, 0x5f, 0x73, 0x35, 0x68,
+        0xee, 0x68, 0xec, 0x41, 0x48, 0x8d, 0x53, 0x14,
     }, {
         /* Origin `https://mycrypto.com` */
-        28,   61,  11,  30,  98, 192,  30, 135,
-        248, 150, 135, 249,  82,  13,  52,  25,
-        47,  180, 215,  24, 230, 252,  58,  95,
-        99,  215, 241,  59, 221, 131, 149, 189
+        0xbd, 0x22, 0x66, 0x24, 0x02, 0x18, 0x8c, 0x4d,
+        0xba, 0x4b, 0xb3, 0xd7, 0xe3, 0x98, 0x00, 0x7c,
+        0x5b, 0x98, 0x6f, 0x46, 0x27, 0x1f, 0x6d, 0xf9,
+        0x2e, 0x24, 0x01, 0xa7, 0xce, 0xfd, 0x1a, 0xa8,
     }
 };
 
@@ -313,7 +319,7 @@ static void u2f_device_authenticate(const USB_APDU *a)
     for (i = 0; i < U2F_HIJACK_ORIGIN_TOTAL; i++) {
         // As an alternative interface, hijack the U2F AUTH key handle data field.
         // Slower but works in browsers for specified sites without requiring an extension.
-        if (MEMEQ(req->challenge, U2F_HIJACK_CODE[i], U2F_NONCE_LENGTH)) {
+        if (MEMEQ(req->appId, U2F_HIJACK_CODE[i], U2F_APPID_SIZE)) {
             if (!(memory_report_ext_flags() & MEM_EXT_MASK_U2F_HIJACK)) {
                 // Abort U2F hijack commands if the U2F_hijack bit is not set (== disabled).
                 u2f_send_err_hid(cid, U2FHID_ERR_CHANNEL_BUSY);

--- a/src/u2f_device.h
+++ b/src/u2f_device.h
@@ -35,10 +35,10 @@
 #include "u2f/u2f.h"
 
 
-#define U2F_HIJACK_ORIGIN_TOTAL 3
+#define U2F_HIJACK_ORIGIN_TOTAL 4
 
 
-extern const uint8_t U2F_HIJACK_CODE[U2F_HIJACK_ORIGIN_TOTAL][U2F_NONCE_LENGTH];
+extern const uint8_t U2F_HIJACK_CODE[U2F_HIJACK_ORIGIN_TOTAL][U2F_APPID_SIZE];
 
 
 void u2f_send_message(const uint8_t *data, const uint32_t len);

--- a/tests/api.h
+++ b/tests/api.h
@@ -73,7 +73,7 @@ static const char hidden_pwd[] = "hide";
 static uint8_t KEY_STANDARD[MEM_PAGE_LEN];
 static uint8_t KEY_HIDDEN[MEM_PAGE_LEN];
 static char command_sent[COMMANDER_REPORT_SIZE] = {0};
-const uint8_t U2F_HIJACK_CODE[U2F_HIJACK_ORIGIN_TOTAL][U2F_NONCE_LENGTH];// extern
+const uint8_t U2F_HIJACK_CODE[U2F_HIJACK_ORIGIN_TOTAL][U2F_APPID_SIZE];// extern
 static unsigned char HID_REPORT[HID_REPORT_SIZE] = {0};
 static char decrypted_report[COMMANDER_REPORT_SIZE];
 
@@ -375,7 +375,7 @@ static void api_hid_send_len(const char *cmd, int cmdlen)
             auth_req->keyHandle[1] = idx;
             memcpy(auth_req->keyHandle + 2, cmd + idx * kh_max_len, MIN(kh_max_len, MAX(0,
                     cmdlen - idx * kh_max_len)));
-            memcpy(auth_req->challenge, U2F_HIJACK_CODE, U2F_NONCE_LENGTH);
+            memcpy(auth_req->appId, U2F_HIJACK_CODE, U2F_APPID_SIZE);
             api_hid_send_frames(HWW_CID, U2FHID_MSG, buf, sizeof(buf));
         }
     } else {


### PR DESCRIPTION
MyEtherWallet redid their website and put the old version of MEW at vintage.myetherwallet.com.

In addition, the 'hijack code' was changed from the U2F `challenge` parameter to the `appId` parameter, as the latter is a more stable representation of the website origin (for anti-phishing purposes). This was made apparent as the latest Chrome version changed how the `challenge` parameter was computed.