### PR TITLE
Wallet: Allow Change outputs for 48' multisig paths

### DIFF
--- a/src/wallet.c
+++ b/src/wallet.c
@@ -162,7 +162,7 @@ int wallet_check_change_keypath(const uint32_t utxo[MAX_PARSE_KEYPATH_LEVEL],
     }
 
     // Check the change keypath's change level
-    if (change[change_depth - 2] != 1) {
+    if (change[change_depth - 2] != 1 && change[change_depth - 2] != 0) {
         return DBB_ERROR;
     }
     // Check that the change keypath address level is within range


### PR DESCRIPTION
Electrum and Copay use multisig paths marked with the 48' purpose. These paths have the format of m / purpose' / coin_type' / account' / script_type' . This means that unlike standard BIP44 derivation keypaths the change and address_index codes are one level deeper.
This is just a draft pull request to get the discussion on this issue started.